### PR TITLE
renaming throttler->freno

### DIFF
--- a/go/cmd/freno/main.go
+++ b/go/cmd/freno/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	gohttp "net/http"
 
-	"github.com/github/throttler/go/http"
+	"github.com/github/freno/go/http"
 	"github.com/outbrain/golib/log"
 )
 


### PR DESCRIPTION
Due to rename `throttler`->`freno`, golang package `throttle` had to rename as well, and so have source files.
