### PR TITLE
pt-archiver plugin perl change to be compatible with older perl

### DIFF
--- a/resources/pt-archiver/FrenoThrottler.pm
+++ b/resources/pt-archiver/FrenoThrottler.pm
@@ -38,7 +38,7 @@ sub new {
 
   # As example, you may read URL or cluster hint from your database:
   #
-  #  my $dbh = %args{"dbh"};
+  #  my $dbh = $args{"dbh"};
   #  my ($cluster) = $dbh->selectrow_array("select cluster_name from meta.cluster limit 1");
   #  if ($cluster eq "" || not defined $cluster) {
   #    die "Cannot find cluster";


### PR DESCRIPTION
This minor syntax change makes the throttler plugin work on older Perl versions, such as `5.14.*`