### PR TITLE
ON HOLD: Chatops RPC

### DIFF
--- a/go/cmd/freno/main.go
+++ b/go/cmd/freno/main.go
@@ -114,6 +114,7 @@ func httpServe() error {
 	throttlerCheck.SelfChecks()
 	api := http.NewAPIImpl(throttlerCheck, consensusService)
 	router := http.ConfigureRoutes(api)
+	api.ConfigureChatops(router)
 	port := config.Settings().ListenPort
 	log.Infof("Starting server in port %d", port)
 	return gohttp.ListenAndServe(fmt.Sprintf(":%d", port), router)

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -87,29 +87,29 @@ func (config *Configuration) Reload() error {
 // Some of the settinges have reasonable default values, and some other
 // (like database credentials) are strictly expected from user.
 type ConfigurationSettings struct {
-	ListenPort      int
+	ListenPort        int    // HTTP port. 0 disables
+	HTTPSListenPort   int    // HTTPS port. Value of 0 disables (default: 0)
+	SSLPrivateKeyFile string //
+	SSLCertFile       string //
+
 	RaftBind        string
 	RaftDataDir     string
 	DefaultRaftPort int      // if a RaftNodes entry does not specify port, use this one
 	RaftNodes       []string // Raft nodes to make initial connection with
-	// Debug                                        bool   // set debug mode (similar to --debug option)
-	// ListenSocket                                 string // Where freno HTTP should listen for unix socket (default: empty; when given, TCP is disabled)
-	// AnExampleSliceOfStrings                    []string // Add a comment here
-	// AnExampleMapOfStringsToStrings    map[string]string // Add a comment here
+
 	Stores StoresSettings
 }
 
 func newConfigurationSettings() *ConfigurationSettings {
 	return &ConfigurationSettings{
-		ListenPort:      8087,
-		RaftBind:        "127.0.0.1:10008",
-		RaftDataDir:     "",
-		DefaultRaftPort: 0,
-		RaftNodes:       []string{},
-		//Debug:                                        false,
-		//ListenSocket:                                 "",
-		//AnExampleListOfStrings:                       []string{"*"},
-		//AnExampleMapOfStringsToStrings:               make(map[string]string),
+		ListenPort:        8087,
+		HTTPSListenPort:   0,
+		SSLPrivateKeyFile: "",
+		SSLCertFile:       "",
+		RaftBind:          "127.0.0.1:10008",
+		RaftDataDir:       "",
+		DefaultRaftPort:   0,
+		RaftNodes:         []string{},
 	}
 }
 

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -47,6 +47,7 @@ type APIImpl struct {
 	throttlerCheck   *throttle.ThrottlerCheck
 	consensusService group.ConsensusService
 	hostname         string
+	chatops          *Chatops
 }
 
 // NewAPIImpl creates a new instance of the API implementation
@@ -202,6 +203,20 @@ func (api *APIImpl) ThrottledApps(w http.ResponseWriter, r *http.Request, ps htt
 func (api *APIImpl) Help(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(endpoints)
+}
+
+// ThrottledApps returns a snapshot of all currently throttled apps
+func (api *APIImpl) Chatops(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(api.chatops)
+}
+
+func (api *APIImpl) ConfigureChatops(router *httprouter.Router) {
+	api.chatops = NewChatops()
+	api.chatops.AddMethod("metrics", NewChatopsMethod("metrics", EmptyParams, "metrics", "all aggregated probed metrics"))
+
+	register(router, "/_chatops", api.Chatops)
+	register(router, "/_chatops/metrics", api.AggregatedMetrics)
 }
 
 // register is a wrapper function for accepting both GET and HEAD requests

--- a/go/http/chatops.go
+++ b/go/http/chatops.go
@@ -1,0 +1,53 @@
+//
+// Chatops-RPC
+// This is intended to provide well formed API information to hubot.
+// GitHub's implementation is its own, but this can serve other automation as well.
+//
+
+package http
+
+import (
+	"fmt"
+)
+
+const frenoNamespace = "freno"
+
+var EmptyParams = []string{}
+
+type ChatopsMethod struct {
+	Help   string   `json:"help"`
+	Regex  string   `json:"regex"`
+	Params []string `json:"params"`
+	Path   string   `json:"path"`
+}
+
+func NewChatopsMethod(regexSuffix string, params []string, path string, help string) *ChatopsMethod {
+	return &ChatopsMethod{
+		Regex:  fmt.Sprintf(`^%s\s+%s`, frenoNamespace, regexSuffix),
+		Params: params,
+		Path:   path,
+		Help:   help,
+	}
+}
+
+type Chatops struct {
+	Namespace     string
+	Help          string
+	Version       int
+	ErrorResponse string
+	Methods       map[string]ChatopsMethod
+}
+
+func NewChatops() *Chatops {
+	return &Chatops{
+		Namespace:     frenoNamespace,
+		Help:          "n/a",
+		Version:       2,
+		ErrorResponse: "see freno documentation, https://github.com/github/freno/tree/master/doc",
+		Methods:       make(map[string]ChatopsMethod),
+	}
+}
+
+func (chatops *Chatops) AddMethod(name string, method *ChatopsMethod) {
+	chatops.Methods[name] = *method
+}


### PR DESCRIPTION
This PR adds chatops-RPC to `freno`. 

### Work in progress

Chatops RPC allows seamless integration between `freno` and [hubot](https://github.com/github/hubot).

The general user will probably not use this; however those who use chatops will hopefully easily recognize that the `/_chatops` path provides well formed metadata on available commands and params.

cc @miguelff @bhuga 