### PR TITLE
Tracking recent apps usage

### DIFF
--- a/doc/http.md
+++ b/doc/http.md
@@ -73,6 +73,14 @@ Notes:
 
 - `/throttled-apps`: list currently throttled apps.
 
+##### Usage
+
+- `/recent-apps/<lastMinutes>`: list app/host that have `/check`ed `freno` in the past given minutes. Example:
+
+  - `/recent-apps/30` show which apps from which hosts have issued `check` requests in the past `30` minutes
+
+- `/recent-apps`: no time limit; `freno` keeps up to `24h` of `check` requests.
+
 ### General requests
 
 - `/lb-check`: returns `HTTP 200`. Indicates the node is alive

--- a/go/base/recent_app.go
+++ b/go/base/recent_app.go
@@ -7,13 +7,13 @@ import (
 // AppThrottle is the definition for an app throtting instruction
 // - Ratio: [0..1], 0 == no throttle, 1 == fully throttle
 type RecentApp struct {
-	CheckedAt           int64
+	CheckedAtEpoch      int64
 	MinutesSinceChecked int64
 }
 
 func NewRecentApp(checkedAt time.Time) *RecentApp {
 	result := &RecentApp{
-		CheckedAt:           checkedAt.Unix(),
+		CheckedAtEpoch:      checkedAt.Unix(),
 		MinutesSinceChecked: int64(time.Since(checkedAt).Minutes()),
 	}
 	return result

--- a/go/base/recent_app.go
+++ b/go/base/recent_app.go
@@ -1,0 +1,20 @@
+package base
+
+import (
+	"time"
+)
+
+// AppThrottle is the definition for an app throtting instruction
+// - Ratio: [0..1], 0 == no throttle, 1 == fully throttle
+type RecentApp struct {
+	CheckedAt            time.Time
+	DurationSinceChecked time.Duration
+}
+
+func NewRecentApp(checkedAt time.Time) *RecentApp {
+	result := &RecentApp{
+		CheckedAt:            checkedAt,
+		DurationSinceChecked: time.Since(checkedAt),
+	}
+	return result
+}

--- a/go/base/recent_app.go
+++ b/go/base/recent_app.go
@@ -7,14 +7,14 @@ import (
 // AppThrottle is the definition for an app throtting instruction
 // - Ratio: [0..1], 0 == no throttle, 1 == fully throttle
 type RecentApp struct {
-	CheckedAt            time.Time
-	DurationSinceChecked time.Duration
+	CheckedAt           time.Time
+	MinutesSinceChecked int64
 }
 
 func NewRecentApp(checkedAt time.Time) *RecentApp {
 	result := &RecentApp{
-		CheckedAt:            checkedAt,
-		DurationSinceChecked: time.Since(checkedAt),
+		CheckedAt:           checkedAt,
+		MinutesSinceChecked: int64(time.Since(checkedAt).Minutes()),
 	}
 	return result
 }

--- a/go/base/recent_app.go
+++ b/go/base/recent_app.go
@@ -7,13 +7,13 @@ import (
 // AppThrottle is the definition for an app throtting instruction
 // - Ratio: [0..1], 0 == no throttle, 1 == fully throttle
 type RecentApp struct {
-	CheckedAt           time.Time
+	CheckedAt           int64
 	MinutesSinceChecked int64
 }
 
 func NewRecentApp(checkedAt time.Time) *RecentApp {
 	result := &RecentApp{
-		CheckedAt:           checkedAt,
+		CheckedAt:           checkedAt.Unix(),
 		MinutesSinceChecked: int64(time.Since(checkedAt).Minutes()),
 	}
 	return result

--- a/go/group/consensus_service.go
+++ b/go/group/consensus_service.go
@@ -11,4 +11,5 @@ type ConsensusService interface {
 	ThrottleApp(appName string, expireAt time.Time, ratio float64) error
 	ThrottledAppsMap() (result map[string](*base.AppThrottle))
 	UnthrottleApp(appName string) error
+	RecentAppsMap() (result map[string](*base.RecentApp))
 }

--- a/go/group/store.go
+++ b/go/group/store.go
@@ -158,6 +158,10 @@ func (store *Store) ThrottledAppsMap() (result map[string](*base.AppThrottle)) {
 	return store.throttler.ThrottledAppsMap()
 }
 
+func (store *Store) RecentAppsMap() (result map[string](*base.RecentApp)) {
+	return store.throttler.RecentAppsMap()
+}
+
 // Join joins a node, located at addr, to this store. The node must be ready to
 // respond to Raft communications at that address.
 func (store *Store) Join(addr string) error {

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -3,10 +3,10 @@ package http
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/github/freno/go/group"
@@ -142,12 +142,8 @@ func (api *APIImpl) Check(w http.ResponseWriter, r *http.Request, ps httprouter.
 	remoteAddr := r.Header.Get("X-Forwarded-For")
 	if remoteAddr == "" {
 		remoteAddr = r.RemoteAddr
+		remoteAddr = strings.Split(remoteAddr, ":")[0]
 	}
-	fmt.Println(fmt.Sprintf("zzzzzzzzz  X-Forwarded-For headers: %+v, %+v", len(r.Header[" X-Forwarded-For"]), r.Header[" X-Forwarded-For"]))
-	for k, v := range r.Header {
-		fmt.Println(fmt.Sprintf("zzzzzzzzz  header: %+v, %+v", k, v))
-	}
-	remoteAddr, _, _ = net.SplitHostPort(remoteAddr)
 	checkResult := api.throttlerCheck.Check(appName, storeType, storeName, remoteAddr)
 
 	api.respondToCheckRequest(w, r, checkResult)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -208,7 +208,7 @@ func (api *APIImpl) ThrottledApps(w http.ResponseWriter, r *http.Request, ps htt
 func (api *APIImpl) RecentApps(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	w.Header().Set("Content-Type", "application/json")
 	recentApps := api.consensusService.RecentAppsMap()
-	json.NewEncoder(w).Encode(throttledApps)
+	json.NewEncoder(w).Encode(recentApps)
 	// 	var err error
 	// 	var lastMinutes int64
 	// 	if ps.ByName("lastMinutes") != "" {

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -3,6 +3,7 @@ package http
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -142,6 +143,10 @@ func (api *APIImpl) Check(w http.ResponseWriter, r *http.Request, ps httprouter.
 	if remoteAddr == "" {
 		remoteAddr = r.RemoteAddr
 	}
+	for k, v := range r.Header {
+		fmt.Println(fmt.Sprintf("zzzzzzzzz  header: %+v, %+v", k, v))
+	}
+	remoteAddr, _, _ = net.SplitHostPort(remoteAddr)
 	checkResult := api.throttlerCheck.Check(appName, storeType, storeName, remoteAddr)
 
 	api.respondToCheckRequest(w, r, checkResult)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -143,6 +143,7 @@ func (api *APIImpl) Check(w http.ResponseWriter, r *http.Request, ps httprouter.
 	if remoteAddr == "" {
 		remoteAddr = r.RemoteAddr
 	}
+	fmt.Println(fmt.Sprintf("zzzzzzzzz  X-Forwarded-For headers: %+v, %+v", len(r.Header[" X-Forwarded-For"]), r.Header[" X-Forwarded-For"]))
 	for k, v := range r.Header {
 		fmt.Println(fmt.Sprintf("zzzzzzzzz  header: %+v, %+v", k, v))
 	}

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -143,9 +143,6 @@ func (api *APIImpl) Check(w http.ResponseWriter, r *http.Request, ps httprouter.
 	if remoteAddr == "" {
 		remoteAddr = r.RemoteAddr
 	}
-	for k, v := range r.Header {
-		fmt.Println(fmt.Sprintf("zzzzzzzzz  header: %+v, %+v", k, v))
-	}
 	remoteAddr, _, _ = net.SplitHostPort(remoteAddr)
 	checkResult := api.throttlerCheck.Check(appName, storeType, storeName, remoteAddr)
 

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -139,9 +139,12 @@ func (api *APIImpl) Check(w http.ResponseWriter, r *http.Request, ps httprouter.
 	appName := ps.ByName("app")
 	storeType := ps.ByName("storeType")
 	storeName := ps.ByName("storeName")
-	remoteAddr := r.Header.Get("x-forwarded-for")
+	remoteAddr := r.Header.Get("X-Forwarded-For")
 	if remoteAddr == "" {
 		remoteAddr = r.RemoteAddr
+	}
+	for k, v := range r.Header {
+		fmt.Println(fmt.Sprintf("zzzzzzzzz  header: %+v, %+v", k, v))
 	}
 	remoteAddr, _, _ = net.SplitHostPort(remoteAddr)
 	checkResult := api.throttlerCheck.Check(appName, storeType, storeName, remoteAddr)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -138,7 +138,11 @@ func (api *APIImpl) Check(w http.ResponseWriter, r *http.Request, ps httprouter.
 	appName := ps.ByName("app")
 	storeType := ps.ByName("storeType")
 	storeName := ps.ByName("storeName")
-	checkResult := api.throttlerCheck.Check(appName, storeType, storeName, r.RemoteAddr)
+	remoteAddr := r.Header.Get("x-forwarded-for")
+	if remoteAddr == "" {
+		remoteAddr = r.RemoteAddr
+	}
+	checkResult := api.throttlerCheck.Check(appName, storeType, storeName, remoteAddr)
 
 	api.respondToCheckRequest(w, r, checkResult)
 }

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -2,15 +2,17 @@ package throttle
 
 import (
 	"fmt"
-	"github.com/github/freno/go/base"
-	"github.com/github/freno/go/config"
-	"github.com/github/freno/go/haproxy"
-	"github.com/github/freno/go/mysql"
 	"math/rand"
+	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/github/freno/go/base"
+	"github.com/github/freno/go/config"
+	"github.com/github/freno/go/haproxy"
+	"github.com/github/freno/go/mysql"
 
 	"github.com/outbrain/golib/log"
 	"github.com/patrickmn/go-cache"
@@ -379,7 +381,7 @@ func (throttler *Throttler) ThrottledAppsMap() (result map[string](*base.AppThro
 }
 
 func (throttler *Throttler) markRecentApp(appName string, remoteAddr string) {
-	remoteAddrHost := strings.Split(remoteAddr, ":")[0]
+	remoteAddrHost, _, _ := net.SplitHostPort(remoteAddr)
 	recentAppKey := fmt.Sprintf("%s/%s", appName, remoteAddrHost)
 	throttler.recentApps.Set(recentAppKey, time.Now(), cache.DefaultExpiration)
 }

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -379,7 +379,8 @@ func (throttler *Throttler) ThrottledAppsMap() (result map[string](*base.AppThro
 }
 
 func (throttler *Throttler) markRecentApp(appName string, remoteAddr string) {
-	recentAppKey := fmt.Sprintf("%s/%s", appName, remoteAddr)
+	remoteAddrHost := strings.Split(remoteAddr, ":")[0]
+	recentAppKey := fmt.Sprintf("%s/%s", appName, remoteAddrHost)
 	throttler.recentApps.Set(recentAppKey, time.Now(), cache.DefaultExpiration)
 }
 

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -26,6 +26,7 @@ const mysqlAggreateInterval = 50 * time.Millisecond
 const aggregatedMetricsExpiration = 5 * time.Second
 const aggregatedMetricsCleanup = 1 * time.Second
 const throttledAppsSnapshotInterval = 5 * time.Second
+const recentAppsExpiration = time.Hour * 24
 
 const defaultThrottleTTL = 60 * time.Minute
 const DefaultThrottleRatio = 1.0
@@ -47,6 +48,7 @@ type Throttler struct {
 	mysqlClusterThresholds *cache.Cache
 	aggregatedMetrics      *cache.Cache
 	throttledApps          *cache.Cache
+	recentApps             *cache.Cache
 
 	throttledAppsMutex sync.Mutex
 }
@@ -65,6 +67,7 @@ func NewThrottler(isLeaderFunc func() bool) *Throttler {
 		throttledApps:          cache.New(cache.NoExpiration, 10*time.Second),
 		mysqlClusterThresholds: cache.New(cache.NoExpiration, 0),
 		aggregatedMetrics:      cache.New(aggregatedMetricsExpiration, aggregatedMetricsCleanup),
+		recentApps:             cache.New(recentAppsExpiration, time.Minute),
 	}
 	throttler.ThrottleApp("abusing-app", time.Now().Add(time.Hour*24*365*10), DefaultThrottleRatio)
 	return throttler
@@ -371,6 +374,21 @@ func (throttler *Throttler) ThrottledAppsMap() (result map[string](*base.AppThro
 	for appName, item := range throttler.throttledApps.Items() {
 		appThrottle := item.Object.(*base.AppThrottle)
 		result[appName] = appThrottle
+	}
+	return result
+}
+
+func (throttler *Throttler) markRecentApp(appName string, remoteAddr string) {
+	recentAppKey := fmt.Sprintf("%s/%s", appName, remoteAddr)
+	throttler.recentApps.Set(recentAppKey, time.Now(), cache.DefaultExpiration)
+}
+
+func (throttler *Throttler) RecentAppsMap() (result map[string](*base.RecentApp)) {
+	result = make(map[string](*base.RecentApp))
+
+	for recentAppKey, item := range throttler.recentApps.Items() {
+		recentApp := base.NewRecentApp(item.Object.(time.Time))
+		result[recentAppKey] = recentApp
 	}
 	return result
 }

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -3,7 +3,6 @@ package throttle
 import (
 	"fmt"
 	"math/rand"
-	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -381,8 +380,7 @@ func (throttler *Throttler) ThrottledAppsMap() (result map[string](*base.AppThro
 }
 
 func (throttler *Throttler) markRecentApp(appName string, remoteAddr string) {
-	remoteAddrHost, _, _ := net.SplitHostPort(remoteAddr)
-	recentAppKey := fmt.Sprintf("%s/%s", appName, remoteAddrHost)
+	recentAppKey := fmt.Sprintf("%s/%s", appName, remoteAddr)
 	throttler.recentApps.Set(recentAppKey, time.Now(), cache.DefaultExpiration)
 }
 


### PR DESCRIPTION
This PR tracks down recent apps:

- which app made checks recently?
- from what remote address?

This, in addition to the `/recent-apps` API, will give us better visibility (on top of existing metrics) into what's hitting `freno`.