### PR TITLE
support for IgnoreHostsCount config

### DIFF
--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -36,6 +36,7 @@ You will find the top-level configuration:
   "Password": "${mysql_password_env_variable}",
   "MetricQuery": "select unix_timestamp(now(6)) - unix_timestamp(ts) as lag_check from meta.heartbeat order by ts desc limit 1",
   "ThrottleThreshold": 1.0,
+  "IgnoreHostsCount": 0,
   "Clusters": {
   }
 }
@@ -51,6 +52,7 @@ These params apply in general to all MySQL clusters, unless specified differentl
   - Note: the sefault time unit for replication lag is _seconds_
 - `ThrottleThreshold`: an upper limit for valid collected values. If value collected (via `MetricQuery`) is below or equal to `ThrottleThreshold`, cluster is considered to be good to write to. If higher, then cluster writes will need to be throttled.
   - Note: use _seconds_ as replication lag time unit. In the above we throttle above `1.0` seconds.
+- `IgnoreHostsCount`: number of hosts that can be ignored while aggregating cluster's values. For example, if `IgnoreHostsCount` is `2`, then up to `2` hosts that have errors are silently ignored. Or, if there's no errors, the two highest values will be ignored (so if these two values exceed the cluster's threshold, `freno` may still be happy to allow writes to the cluster).
 
 Looking at clusters configuration:
 
@@ -67,6 +69,7 @@ Looking at clusters configuration:
   "local": {
     "User": "msandbox",
     "Password": "msandbox",
+    "IgnoreHostsCount": 1,
     "StaticHostsSettings" : {
         "Hosts": [
           "127.0.0.1:22293",
@@ -84,7 +87,7 @@ Noteworthy:
 
 - `prod4` chooses to (but doesn't have to) override the `ThrottleThreshold` to `0.8` seconds
 - `prod4` list of servers is dictated by `HAProxy`. `freno` will routinely and dynamically poll given HAProxy server for list of hosts. These will include any hosts not in `NOLB`.
-- `local` cluster chooses to override `User` & `Password`.
+- `local` cluster chooses to override `User`, `Password` and `IgnoreHostsCount`.
 - `local` cluster defines a static list of hosts.
 
 

--- a/go/base/throttle_metric.go
+++ b/go/base/throttle_metric.go
@@ -43,3 +43,15 @@ func (metricResult *noSuchMetric) Get() (float64, error) {
 }
 
 var NoSuchMetric = &noSuchMetric{}
+
+type simpleMetricResult struct {
+	Value float64
+}
+
+func NewSimpleMetricResult(value float64) MetricResult {
+	return &simpleMetricResult{Value: value}
+}
+
+func (metricResult *simpleMetricResult) Get() (float64, error) {
+	return metricResult.Value, nil
+}

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -16,6 +16,7 @@ type MySQLClusterConfigurationSettings struct {
 	MetricQuery       string  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	ThrottleThreshold float64 // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	Port              int     // Specify if different than 3306 or if different than specified by MySQLConfigurationSettings
+	IgnoreHostsCount  int     // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
 
 	HAProxySettings     HAProxyConfigurationSettings // If list of servers is to be acquired via HAProxy, provide this field
 	StaticHostsSettings StaticHostsConfigurationSettings
@@ -41,6 +42,7 @@ type MySQLConfigurationSettings struct {
 	MetricQuery       string
 	ThrottleThreshold float64
 	Port              int // Specify if different than 3306; applies to all clusters
+	IgnoreHostsCount  int // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }
@@ -78,6 +80,9 @@ func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
 		}
 		if clusterSettings.Port == 0 {
 			clusterSettings.Port = settings.Port
+		}
+		if clusterSettings.IgnoreHostsCount == 0 {
+			clusterSettings.IgnoreHostsCount = settings.IgnoreHostsCount
 		}
 	}
 	return nil

--- a/go/group/fsm.go
+++ b/go/group/fsm.go
@@ -2,7 +2,6 @@ package group
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"time"
 
@@ -18,7 +17,7 @@ type fsm Store
 func (f *fsm) Apply(l *raft.Log) interface{} {
 	var c command
 	if err := json.Unmarshal(l.Data, &c); err != nil {
-		panic(fmt.Sprintf("failed to unmarshal command: %s", err.Error()))
+		log.Errorf("failed to unmarshal command: %s", err.Error())
 	}
 
 	log.Debugf("freno/raft: applying command: %+v", c)
@@ -27,9 +26,8 @@ func (f *fsm) Apply(l *raft.Log) interface{} {
 		return f.applyThrottleApp(c.Key, c.ExpireAt, c.Ratio)
 	case "unthrottle":
 		return f.applyUnthrottleApp(c.Key)
-	default:
-		panic(fmt.Sprintf("unrecognized command operation: %s", c.Operation))
 	}
+	return log.Errorf("unrecognized command operation: %s", c.Operation)
 }
 
 // Snapshot returns a snapshot object of freno's state

--- a/go/mysql/mysql_inventory.go
+++ b/go/mysql/mysql_inventory.go
@@ -9,10 +9,12 @@ import (
 	"github.com/github/freno/go/base"
 )
 
+type InstanceMetricResultMap map[InstanceKey]base.MetricResult
+
 type MySQLInventory struct {
 	ClustersProbes     map[string](*Probes)
 	IgnoreHostsCount   map[string]int
-	InstanceKeyMetrics map[InstanceKey]base.MetricResult
+	InstanceKeyMetrics InstanceMetricResultMap
 }
 
 func NewMySQLInventory() *MySQLInventory {

--- a/go/mysql/mysql_inventory.go
+++ b/go/mysql/mysql_inventory.go
@@ -11,12 +11,14 @@ import (
 
 type MySQLInventory struct {
 	ClustersProbes     map[string](*Probes)
+	IgnoreHostsCount   map[string]int
 	InstanceKeyMetrics map[InstanceKey]base.MetricResult
 }
 
 func NewMySQLInventory() *MySQLInventory {
 	inventory := &MySQLInventory{
 		ClustersProbes:     make(map[string](*Probes)),
+		IgnoreHostsCount:   make(map[string]int),
 		InstanceKeyMetrics: make(map[InstanceKey]base.MetricResult),
 	}
 	return inventory

--- a/go/mysql/probe.go
+++ b/go/mysql/probe.go
@@ -26,8 +26,9 @@ type Probe struct {
 type Probes map[InstanceKey](*Probe)
 
 type ClusterProbes struct {
-	ClusterName string
-	Probes      *Probes
+	ClusterName      string
+	IgnoreHostsCount int
+	Probes           *Probes
 }
 
 func NewProbes() *Probes {

--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -61,7 +61,7 @@ func (check *ThrottlerCheck) Check(appName string, storeType string, storeName s
 	case "mysql":
 		{
 			metricResultFunc = func() (metricResult base.MetricResult, threshold float64) {
-				return check.throttler.GetMySQLClusterMetrics(storeName)
+				return check.throttler.getMySQLClusterMetrics(storeName)
 			}
 		}
 	}

--- a/go/throttle/mysql.go
+++ b/go/throttle/mysql.go
@@ -1,0 +1,47 @@
+package throttle
+
+import (
+	"sort"
+
+	"github.com/github/freno/go/base"
+	"github.com/github/freno/go/mysql"
+)
+
+func aggregateMySQLProbes(probes *mysql.Probes, instanceResultsMap mysql.InstanceMetricResultMap, ignoreHostsCount int) (worstMetric base.MetricResult) {
+	// probes is known not to change. It can be *replaced*, but not changed.
+	// so it's safe to iterate it
+	if len(*probes) == 0 {
+		return base.NoHostsMetricResult
+	}
+	probeValues := []float64{}
+	for _, probe := range *probes {
+		instanceMetricResult, ok := instanceResultsMap[probe.Key]
+		if !ok {
+			return base.NoMetricResultYet
+		}
+
+		value, err := instanceMetricResult.Get()
+		if err != nil {
+			if ignoreHostsCount > 0 {
+				// ok to skip this error
+				ignoreHostsCount = ignoreHostsCount - 1
+				continue
+			}
+			return instanceMetricResult
+		}
+
+		// No error
+		probeValues = append(probeValues, value)
+	}
+	// If we got here, that means no errors (or good to skip errors)
+	sort.Float64s(probeValues)
+	for ignoreHostsCount > 0 {
+		if len(probeValues) > 1 {
+			probeValues = probeValues[0 : len(probeValues)-1]
+		}
+		ignoreHostsCount = ignoreHostsCount - 1
+	}
+	worstValue := probeValues[len(probeValues)-1]
+	worstMetric = base.NewSimpleMetricResult(worstValue)
+	return worstMetric
+}

--- a/go/throttle/mysql_test.go
+++ b/go/throttle/mysql_test.go
@@ -28,8 +28,6 @@ func init() {
 }
 
 func TestAggregateMySQLProbesNoErrors(t *testing.T) {
-	throttler := NewThrottler(func() bool { return false })
-
 	instanceResultsMap := mysql.InstanceMetricResultMap{
 		key1: base.NewSimpleMetricResult(1.2),
 		key2: base.NewSimpleMetricResult(1.7),
@@ -42,37 +40,37 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 1)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 2)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.1)
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 3)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 3)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.6)
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 4)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 4)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 5)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 5)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
@@ -80,8 +78,6 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 }
 
 func TestAggregateMySQLProbesWithErrors(t *testing.T) {
-	throttler := NewThrottler(func() bool { return false })
-
 	instanceResultsMap := mysql.InstanceMetricResultMap{
 		key1: base.NewSimpleMetricResult(1.2),
 		key2: base.NewSimpleMetricResult(1.7),
@@ -94,19 +90,19 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 1)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 2)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
@@ -114,19 +110,19 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 
 	instanceResultsMap[key1] = base.NoSuchMetric
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 1)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 2)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -264,7 +264,16 @@ func (throttler *Throttler) pushStatusToExpVar() {
 	}
 }
 
-func (throttler *Throttler) GetMySQLClusterMetrics(clusterName string) (metricResult base.MetricResult, threshold float64) {
+func (throttler *Throttler) getNamedMetric(metricName string) (metricResult base.MetricResult, threshold float64) {
+	if metricResultVal, found := throttler.aggregatedMetrics.Get(metricName); found {
+		metricResult = metricResultVal.(base.MetricResult)
+	} else {
+		return base.NoSuchMetric, 0
+	}
+	return metricResult, threshold
+}
+
+func (throttler *Throttler) getMySQLClusterMetrics(clusterName string) (metricResult base.MetricResult, threshold float64) {
 	if thresholdVal, found := throttler.mysqlClusterThresholds.Get(clusterName); found {
 		threshold, _ = thresholdVal.(float64)
 	} else {
@@ -272,12 +281,7 @@ func (throttler *Throttler) GetMySQLClusterMetrics(clusterName string) (metricRe
 	}
 
 	metricName := fmt.Sprintf("mysql/%s", clusterName)
-	if metricResultVal, found := throttler.aggregatedMetrics.Get(metricName); found {
-		metricResult = metricResultVal.(base.MetricResult)
-	} else {
-		return base.NoSuchMetric, 0
-	}
-	return metricResult, threshold
+	return throttler.getNamedMetric(metricName)
 }
 
 func (throttler *Throttler) aggregatedMetricsSnapshot() map[string]base.MetricResult {

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -3,7 +3,6 @@ package throttle
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -239,45 +238,6 @@ func (throttler *Throttler) updateMySQLClusterProbes(clusterProbes *mysql.Cluste
 	return nil
 }
 
-func (throttler *Throttler) aggregateMySQLProbes(probes *mysql.Probes, instanceResultsMap mysql.InstanceMetricResultMap, ignoreHostsCount int) (worstMetric base.MetricResult) {
-	// probes is known not to change. It can be *replaced*, but not changed.
-	// so it's safe to iterate it
-	if len(*probes) == 0 {
-		return base.NoHostsMetricResult
-	}
-	probeValues := []float64{}
-	for _, probe := range *probes {
-		instanceMetricResult, ok := instanceResultsMap[probe.Key]
-		if !ok {
-			return base.NoMetricResultYet
-		}
-
-		value, err := instanceMetricResult.Get()
-		if err != nil {
-			if ignoreHostsCount > 0 {
-				// ok to skip this error
-				ignoreHostsCount = ignoreHostsCount - 1
-				continue
-			}
-			return instanceMetricResult
-		}
-
-		// No error
-		probeValues = append(probeValues, value)
-	}
-	// If we got here, that means no errors (or good to skip errors)
-	sort.Float64s(probeValues)
-	for ignoreHostsCount > 0 {
-		if len(probeValues) > 1 {
-			probeValues = probeValues[0 : len(probeValues)-1]
-		}
-		ignoreHostsCount = ignoreHostsCount - 1
-	}
-	worstValue := probeValues[len(probeValues)-1]
-	worstMetric = base.NewSimpleMetricResult(worstValue)
-	return worstMetric
-}
-
 // synchronous aggregation of collected data
 func (throttler *Throttler) aggregateMySQLMetrics() error {
 	if !throttler.isLeader {
@@ -286,7 +246,7 @@ func (throttler *Throttler) aggregateMySQLMetrics() error {
 	for clusterName, probes := range throttler.mysqlInventory.ClustersProbes {
 		metricName := fmt.Sprintf("mysql/%s", clusterName)
 		ignoreHostsCount := throttler.mysqlInventory.IgnoreHostsCount[clusterName]
-		aggregatedMetric := throttler.aggregateMySQLProbes(probes, throttler.mysqlInventory.InstanceKeyMetrics, ignoreHostsCount)
+		aggregatedMetric := aggregateMySQLProbes(probes, throttler.mysqlInventory.InstanceKeyMetrics, ignoreHostsCount)
 		go throttler.aggregatedMetrics.Set(metricName, aggregatedMetric, cache.DefaultExpiration)
 	}
 	return nil

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -239,6 +239,45 @@ func (throttler *Throttler) updateMySQLClusterProbes(clusterProbes *mysql.Cluste
 	return nil
 }
 
+func (throttler *Throttler) aggregateMySQLProbes(probes *mysql.Probes, instanceResultsMap mysql.InstanceMetricResultMap, ignoreHostsCount int) (worstMetric base.MetricResult) {
+	// probes is known not to change. It can be *replaced*, but not changed.
+	// so it's safe to iterate it
+	if len(*probes) == 0 {
+		return base.NoHostsMetricResult
+	}
+	probeValues := []float64{}
+	for _, probe := range *probes {
+		instanceMetricResult, ok := instanceResultsMap[probe.Key]
+		if !ok {
+			return base.NoMetricResultYet
+		}
+
+		value, err := instanceMetricResult.Get()
+		if err != nil {
+			if ignoreHostsCount > 0 {
+				// ok to skip this error
+				ignoreHostsCount = ignoreHostsCount - 1
+				continue
+			}
+			return instanceMetricResult
+		}
+
+		// No error
+		probeValues = append(probeValues, value)
+	}
+	// If we got here, that means no errors (or good to skip errors)
+	sort.Float64s(probeValues)
+	for ignoreHostsCount > 0 {
+		if len(probeValues) > 1 {
+			probeValues = probeValues[0 : len(probeValues)-1]
+		}
+		ignoreHostsCount = ignoreHostsCount - 1
+	}
+	worstValue := probeValues[len(probeValues)-1]
+	worstMetric = base.NewSimpleMetricResult(worstValue)
+	return worstMetric
+}
+
 // synchronous aggregation of collected data
 func (throttler *Throttler) aggregateMySQLMetrics() error {
 	if !throttler.isLeader {
@@ -247,44 +286,7 @@ func (throttler *Throttler) aggregateMySQLMetrics() error {
 	for clusterName, probes := range throttler.mysqlInventory.ClustersProbes {
 		metricName := fmt.Sprintf("mysql/%s", clusterName)
 		ignoreHostsCount := throttler.mysqlInventory.IgnoreHostsCount[clusterName]
-		aggregatedMetric := func() (worstMetric base.MetricResult) {
-			// probes is known not to change. It can be *replaced*, but not changed.
-			// so it's safe to iterate it
-			if len(*probes) == 0 {
-				return base.NoHostsMetricResult
-			}
-			probeValues := make([]float64, len(*probes))
-			for _, probe := range *probes {
-				instanceMetricResult, ok := throttler.mysqlInventory.InstanceKeyMetrics[probe.Key]
-				if !ok {
-					return base.NoMetricResultYet
-				}
-
-				value, err := instanceMetricResult.Get()
-				if err != nil {
-					if ignoreHostsCount > 0 {
-						// ok to skip this error
-						ignoreHostsCount = ignoreHostsCount - 1
-						continue
-					}
-					return instanceMetricResult
-				}
-
-				// No error
-				probeValues = append(probeValues, value)
-			}
-			// If we got here, that means no errors (or good to skip errors)
-			sort.Float64s(probeValues)
-			for ignoreHostsCount > 0 {
-				if len(probeValues) > 1 {
-					probeValues = probeValues[0 : len(probeValues)-1]
-				}
-				ignoreHostsCount = ignoreHostsCount - 1
-			}
-			worstValue := probeValues[len(probeValues)-1]
-			worstMetric = base.NewSimpleMetricResult(worstValue)
-			return worstMetric
-		}()
+		aggregatedMetric := throttler.aggregateMySQLProbes(probes, throttler.mysqlInventory.InstanceKeyMetrics, ignoreHostsCount)
 		go throttler.aggregatedMetrics.Set(metricName, aggregatedMetric, cache.DefaultExpiration)
 	}
 	return nil

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -264,13 +264,11 @@ func (throttler *Throttler) pushStatusToExpVar() {
 	}
 }
 
-func (throttler *Throttler) getNamedMetric(metricName string) (metricResult base.MetricResult, threshold float64) {
+func (throttler *Throttler) getNamedMetric(metricName string) (metricResult base.MetricResult) {
 	if metricResultVal, found := throttler.aggregatedMetrics.Get(metricName); found {
-		metricResult = metricResultVal.(base.MetricResult)
-	} else {
-		return base.NoSuchMetric, 0
+		return metricResultVal.(base.MetricResult)
 	}
-	return metricResult, threshold
+	return base.NoSuchMetric
 }
 
 func (throttler *Throttler) getMySQLClusterMetrics(clusterName string) (metricResult base.MetricResult, threshold float64) {
@@ -281,7 +279,7 @@ func (throttler *Throttler) getMySQLClusterMetrics(clusterName string) (metricRe
 	}
 
 	metricName := fmt.Sprintf("mysql/%s", clusterName)
-	return throttler.getNamedMetric(metricName)
+	return throttler.getNamedMetric(metricName), threshold
 }
 
 func (throttler *Throttler) aggregatedMetricsSnapshot() map[string]base.MetricResult {

--- a/go/throttle/throttler_test.go
+++ b/go/throttle/throttler_test.go
@@ -38,7 +38,7 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 		key5: base.NewSimpleMetricResult(1.1),
 	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
-	for key, _ := range instanceResultsMap {
+	for key := range instanceResultsMap {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
@@ -90,7 +90,7 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 		key5: base.NewSimpleMetricResult(1.1),
 	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
-	for key, _ := range instanceResultsMap {
+	for key := range instanceResultsMap {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{

--- a/go/throttle/throttler_test.go
+++ b/go/throttle/throttler_test.go
@@ -1,0 +1,134 @@
+/*
+   Copyright 2017 GitHub Inc.
+	 See https://github.com/github/freno/blob/master/LICENSE
+*/
+
+package throttle
+
+import (
+	"testing"
+
+	"github.com/github/freno/go/base"
+	"github.com/github/freno/go/mysql"
+
+	"github.com/outbrain/golib/log"
+	test "github.com/outbrain/golib/tests"
+)
+
+var (
+	key1 = mysql.InstanceKey{Hostname: "10.0.0.1", Port: 3306}
+	key2 = mysql.InstanceKey{Hostname: "10.0.0.2", Port: 3306}
+	key3 = mysql.InstanceKey{Hostname: "10.0.0.3", Port: 3306}
+	key4 = mysql.InstanceKey{Hostname: "10.0.0.4", Port: 3306}
+	key5 = mysql.InstanceKey{Hostname: "10.0.0.5", Port: 3306}
+)
+
+func init() {
+	log.SetLevel(log.ERROR)
+}
+
+func TestAggregateMySQLProbesNoErrors(t *testing.T) {
+	throttler := NewThrottler(func() bool { return false })
+
+	instanceResultsMap := mysql.InstanceMetricResultMap{
+		key1: base.NewSimpleMetricResult(1.2),
+		key2: base.NewSimpleMetricResult(1.7),
+		key3: base.NewSimpleMetricResult(0.3),
+		key4: base.NewSimpleMetricResult(0.6),
+		key5: base.NewSimpleMetricResult(1.1),
+	}
+	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
+	for key, _ := range instanceResultsMap {
+		probes[key] = &mysql.Probe{Key: key}
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 0)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 1.7)
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 1)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 1.2)
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 2)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 1.1)
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 3)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 0.6)
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 4)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 0.3)
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 5)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 0.3)
+	}
+}
+
+func TestAggregateMySQLProbesWithErrors(t *testing.T) {
+	throttler := NewThrottler(func() bool { return false })
+
+	instanceResultsMap := mysql.InstanceMetricResultMap{
+		key1: base.NewSimpleMetricResult(1.2),
+		key2: base.NewSimpleMetricResult(1.7),
+		key3: base.NewSimpleMetricResult(0.3),
+		key4: base.NoSuchMetric,
+		key5: base.NewSimpleMetricResult(1.1),
+	}
+	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
+	for key, _ := range instanceResultsMap {
+		probes[key] = &mysql.Probe{Key: key}
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 0)
+		_, err := worstMetric.Get()
+		test.S(t).ExpectNotNil(err)
+		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 1)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 1.7)
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 2)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 1.2)
+	}
+
+	instanceResultsMap[key1] = base.NoSuchMetric
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 0)
+		_, err := worstMetric.Get()
+		test.S(t).ExpectNotNil(err)
+		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 1)
+		_, err := worstMetric.Get()
+		test.S(t).ExpectNotNil(err)
+		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
+	}
+	{
+		worstMetric := throttler.aggregateMySQLProbes(&probes, instanceResultsMap, 2)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 1.7)
+	}
+}


### PR DESCRIPTION
Storyline: https://github.com/github/freno/issues/29

This PR adds the `IgnoreHostsCount` config (in both general-MySQL scope as well as specific MySQL cluster scope).

With this setting (default `0`), up to `n` hosts can be safely ignored while aggregating metrics. Say `IgnoreHostsCount` is set to `1`. Then in a cluster, `1` host may be down, or return an error. Or `1` host may exceed threshold -- and will be ignored. 
If all other hosts are good and with values < threshold, then `freno` is happy to ignore those `n` hosts.

cc @github/database-infrastructure 