### PR TITLE
supporting /check-read with user provided threshold

### DIFF
--- a/doc/http.md
+++ b/doc/http.md
@@ -87,6 +87,16 @@ Notes:
 - `/leader-check`: returns `HTTP 200` when the node is the `raft` leader, or `404` otherwise.
 - `/hostname`: node host name
 
+### Specialized requests
+
+- `/check-read/<app>/<store-type>/<store-name>/<threshold>`: a specialized check to see whether current value is lower than given threshold.
+
+  As an example, consider `/check-read/archive/mysql/main1/2.5`. This checks whether the current `mysql/main1` store's value is smaller than or equals to `2.5`. The store's configured threshold value is ignored and not tested in this check.
+
+  This read-check _should not be used to approve writes_. Writes should only be approved by using the `/check` request.
+
+  However this check is known to be useful, at least in one common scenario: a monitoring of a MySQL cluster based on replication lag. In such case, we may have write requests followed by read requests. We may happen to know the elapsed time between write & read. As an example, say `2.5s` have passed between the write and read. The check `/check-read/archive/mysql/main1/2.5` confirms or denies that relevant replicas are up-to-date for the `2.5s` elapsed time. We can therefore read from the replicas and safely expect to find the data we wrote `2.5s` ago on the master.
+
 ### Other requests
 
 - `/help`: show all supported request paths

--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -46,11 +46,13 @@ These params apply in general to all MySQL clusters, unless specified differentl
 
 - `User`, `Password`: these can be specified as plaintext, or in a `${some_env_variable}` format, in which case `freno` will look up its environment for specified variable. (e.g. to match the above config, a `shell` script invoking `freno` can `export mysql_password_env_variable=flyingcircus`)
 - `MetricQuery`:
+  - Note: returned value is expected to be `[0..)` (`0` or more), where lower values are "better" and higher values are "worse".
   - if not provided, `freno` will assume you're interested in replication lag, and will issue a `SHOW SLAVE STATUS` to extract `Seconds_behind_master`
   - We strongly recommend using a custom heartbeat mechanism such as `pt-heartbeat`, with subsecond resolution. The sample query above works well with `pt-heartbeat` subsecond timestamps.
   - Strictly speaking, you don't have to provide a replication-lag metric. This could be any query that reports any metric. However you're likely interested in replication lag to start with.
   - Note: the sefault time unit for replication lag is _seconds_
 - `ThrottleThreshold`: an upper limit for valid collected values. If value collected (via `MetricQuery`) is below or equal to `ThrottleThreshold`, cluster is considered to be good to write to. If higher, then cluster writes will need to be throttled.
+  - Note: valid range is `[0..)` (`0` or more), where lower values are stricter and higher values are more permissive.
   - Note: use _seconds_ as replication lag time unit. In the above we throttle above `1.0` seconds.
 - `IgnoreHostsCount`: number of hosts that can be ignored while aggregating cluster's values. For example, if `IgnoreHostsCount` is `2`, then up to `2` hosts that have errors are silently ignored. Or, if there's no errors, the two highest values will be ignored (so if these two values exceed the cluster's threshold, `freno` may still be happy to allow writes to the cluster).
 

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -24,7 +24,8 @@ type API interface {
 	RaftLeader(w http.ResponseWriter, _ *http.Request, _ httprouter.Params)
 	RaftState(w http.ResponseWriter, _ *http.Request, _ httprouter.Params)
 	Hostname(w http.ResponseWriter, _ *http.Request, _ httprouter.Params)
-	Check(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
+	WriteCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
+	ReadCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	AggregatedMetrics(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	ThrottleApp(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	UnthrottleApp(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
@@ -134,8 +135,8 @@ func (api *APIImpl) respondToCheckRequest(w http.ResponseWriter, r *http.Request
 	}
 }
 
-// CheckMySQLCluster checks whether a cluster's collected metric is within its threshold
-func (api *APIImpl) Check(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+// Check checks whether a collected metric is within its threshold
+func (api *APIImpl) check(w http.ResponseWriter, r *http.Request, ps httprouter.Params, overrideThreshold float64) {
 	appName := ps.ByName("app")
 	storeType := ps.ByName("storeType")
 	storeName := ps.ByName("storeName")
@@ -145,18 +146,23 @@ func (api *APIImpl) Check(w http.ResponseWriter, r *http.Request, ps httprouter.
 		remoteAddr = strings.Split(remoteAddr, ":")[0]
 	}
 
-	var overrideThreshold float64
-	if overrideThresholdParam := ps.ByName("threshold"); overrideThresholdParam != "" {
-		var err error
-		if overrideThreshold, err = strconv.ParseFloat(overrideThresholdParam, 64); err != nil {
-			api.respondGeneric(w, r, err)
-			return
-		}
-	}
-
 	checkResult := api.throttlerCheck.Check(appName, storeType, storeName, remoteAddr, overrideThreshold)
 
 	api.respondToCheckRequest(w, r, checkResult)
+}
+
+// WriteCheck
+func (api *APIImpl) WriteCheck(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	api.check(w, r, ps, 0)
+}
+
+// ReadCheck
+func (api *APIImpl) ReadCheck(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if overrideThreshold, err := strconv.ParseFloat(ps.ByName("threshold"), 64); err != nil {
+		api.respondGeneric(w, r, err)
+	} else {
+		api.check(w, r, ps, overrideThreshold)
+	}
 }
 
 // AggregatedMetrics returns a snapshot of all current aggregated metrics
@@ -275,8 +281,8 @@ func ConfigureRoutes(api API) *httprouter.Router {
 	register(router, "/raft/state", api.RaftState)
 	register(router, "/hostname", api.Hostname)
 
-	register(router, "/check/:app/:storeType/:storeName", api.Check)
-	register(router, "/check-read/:app/:storeType/:storeName/:threshold", api.Check)
+	register(router, "/check/:app/:storeType/:storeName", api.WriteCheck)
+	register(router, "/check-read/:app/:storeType/:storeName/:threshold", api.ReadCheck)
 	register(router, "/aggregated-metrics", api.AggregatedMetrics)
 
 	register(router, "/throttle-app/:app", api.ThrottleApp)

--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -25,8 +25,11 @@ func NewThrottlerCheck(throttler *Throttler) *ThrottlerCheck {
 }
 
 // checkAppMetricResult allows an app to check on a metric
-func (check *ThrottlerCheck) checkAppMetricResult(appName string, metricResultFunc base.MetricResultFunc) (checkResult *CheckResult) {
+func (check *ThrottlerCheck) checkAppMetricResult(appName string, metricResultFunc base.MetricResultFunc, overrideThreshold float64) (checkResult *CheckResult) {
 	metricResult, threshold := check.throttler.AppRequestMetricResult(appName, metricResultFunc)
+	if overrideThreshold > 0 {
+		threshold = overrideThreshold
+	}
 	value, err := metricResult.Get()
 	if appName == "" {
 		return NewCheckResult(http.StatusExpectationFailed, value, threshold, fmt.Errorf("no app indicated"))
@@ -55,7 +58,7 @@ func (check *ThrottlerCheck) checkAppMetricResult(appName string, metricResultFu
 }
 
 // CheckAppStoreMetric
-func (check *ThrottlerCheck) Check(appName string, storeType string, storeName string, remoteAddr string) (checkResult *CheckResult) {
+func (check *ThrottlerCheck) Check(appName string, storeType string, storeName string, remoteAddr string, overrideThreshold float64) (checkResult *CheckResult) {
 	var metricResultFunc base.MetricResultFunc
 	switch storeType {
 	case "mysql":
@@ -69,7 +72,7 @@ func (check *ThrottlerCheck) Check(appName string, storeType string, storeName s
 		return NoSuchMetricCheckResult
 	}
 
-	checkResult = check.checkAppMetricResult(appName, metricResultFunc)
+	checkResult = check.checkAppMetricResult(appName, metricResultFunc, overrideThreshold)
 
 	go func(statusCode int) {
 		metrics.GetOrRegisterCounter("check.any.total", nil).Inc(1)
@@ -100,7 +103,7 @@ func (check *ThrottlerCheck) localCheck(appName string, metricName string) (chec
 	}
 	storeType := metricTokens[0]
 	storeName := metricTokens[1]
-	return check.Check(appName, storeType, storeName, "local")
+	return check.Check(appName, storeType, storeName, "local", 0)
 }
 
 // AggregatedMetrics is a convenience acces method into throttler's `aggregatedMetricsSnapshot`


### PR DESCRIPTION
A new API endpoint, `/check-read/<app>/<store-type>/<store-name>/<threshold>`, allows one to test the current store's value with a user-given threshold, overriding the configured threshold.

This read-check _should not be used to approve writes_. Writes should only be approved by using the `/check` request.

  However this check is known to be useful, at least in one common scenario: a monitoring of a MySQL cluster based on replication lag. In such case, we may have write requests followed by read requests. We may happen to know the elapsed time between write & read. As an example, say `2.5s` have passed between the write and read. The check `/check-read/archive/mysql/main1/2.5` confirms or denies that relevant replicas are up-to-date for the `2.5s` elapsed time. We can therefore read from the replicas and safely expect to find the data we wrote `2.5s` ago on the master.
