### PR TITLE
producing metrics for time-since-metric-check-was-ok

### DIFF
--- a/go/base/metric_health.go
+++ b/go/base/metric_health.go
@@ -1,0 +1,20 @@
+package base
+
+import (
+	"time"
+)
+
+// MetricHealth is a health status for a metric, and more specifically,
+// when it was last checked to be "OK"
+type MetricHealth struct {
+	LastHealthyAt           time.Time
+	SecondsSinceLastHealthy int64
+}
+
+func NewMetricHealth(lastHealthyAt time.Time) *MetricHealth {
+	result := &MetricHealth{
+		LastHealthyAt:           lastHealthyAt,
+		SecondsSinceLastHealthy: int64(time.Since(lastHealthyAt).Seconds()),
+	}
+	return result
+}

--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -108,8 +108,9 @@ func (check *ThrottlerCheck) localCheck(appName string, metricName string) (chec
 	if checkResult.StatusCode == http.StatusOK {
 		check.throttler.markMetricHealthy(metricName)
 	}
-	timeSinceLastOK := check.throttler.timeSinceMetricHealthy(metricName)
-	metrics.GetOrRegisterGauge(fmt.Sprintf("check.%s.%s.seconds_since_healthy", storeType, storeName), nil).Update(int64(timeSinceLastOK.Seconds()))
+	if timeSinceHealthy, found := check.throttler.timeSinceMetricHealthy(metricName); found {
+		metrics.GetOrRegisterGauge(fmt.Sprintf("check.%s.%s.seconds_since_healthy", storeType, storeName), nil).Update(int64(timeSinceHealthy.Seconds()))
+	}
 
 	return checkResult
 }

--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -106,10 +106,10 @@ func (check *ThrottlerCheck) localCheck(appName string, metricName string) (chec
 	checkResult = check.Check(appName, storeType, storeName, "local", 0)
 
 	if checkResult.StatusCode == http.StatusOK {
-		check.throttler.markLastOK(metricName)
+		check.throttler.markMetricHealthy(metricName)
 	}
-	timeSinceLastOK := check.throttler.timeSinceLastMetricOK(metricName)
-	metrics.GetOrRegisterGauge(fmt.Sprintf("check.%s.%s.seconds_since_ok", storeType, storeName), nil).Update(int64(timeSinceLastOK.Seconds()))
+	timeSinceLastOK := check.throttler.timeSinceMetricHealthy(metricName)
+	metrics.GetOrRegisterGauge(fmt.Sprintf("check.%s.%s.seconds_since_healthy", storeType, storeName), nil).Update(int64(timeSinceLastOK.Seconds()))
 
 	return checkResult
 }
@@ -117,6 +117,11 @@ func (check *ThrottlerCheck) localCheck(appName string, metricName string) (chec
 // AggregatedMetrics is a convenience acces method into throttler's `aggregatedMetricsSnapshot`
 func (check *ThrottlerCheck) AggregatedMetrics() map[string]base.MetricResult {
 	return check.throttler.aggregatedMetricsSnapshot()
+}
+
+// MetricsHealth is a convenience acces method into throttler's `metricsHealthSnapshot`
+func (check *ThrottlerCheck) MetricsHealth() map[string](*base.MetricHealth) {
+	return check.throttler.metricsHealthSnapshot()
 }
 
 func (check *ThrottlerCheck) SelfChecks() {

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -50,6 +50,7 @@ type Throttler struct {
 	aggregatedMetrics      *cache.Cache
 	throttledApps          *cache.Cache
 	recentApps             *cache.Cache
+	lastMetricOKCheck      *cache.Cache
 
 	throttledAppsMutex sync.Mutex
 }
@@ -69,6 +70,7 @@ func NewThrottler(isLeaderFunc func() bool) *Throttler {
 		mysqlClusterThresholds: cache.New(cache.NoExpiration, 0),
 		aggregatedMetrics:      cache.New(aggregatedMetricsExpiration, aggregatedMetricsCleanup),
 		recentApps:             cache.New(recentAppsExpiration, time.Minute),
+		lastMetricOKCheck:      cache.New(cache.NoExpiration, 0),
 	}
 	throttler.ThrottleApp("abusing-app", time.Now().Add(time.Hour*24*365*10), DefaultThrottleRatio)
 	return throttler
@@ -373,6 +375,21 @@ func (throttler *Throttler) RecentAppsMap() (result map[string](*base.RecentApp)
 		result[recentAppKey] = recentApp
 	}
 	return result
+}
+
+// markLastOK will mark the time "now" as the last time a given metric was checked to be "OK"
+func (throttler *Throttler) markLastOK(metricName string) {
+	throttler.lastMetricOKCheck.Set(metricName, time.Now(), cache.DefaultExpiration)
+}
+
+// timeSinceLastMetricOK returns time elapsed since the last time a metric checked "OK"
+func (throttler *Throttler) timeSinceLastMetricOK(metricName string) time.Duration {
+	if lastOKTime, found := throttler.lastMetricOKCheck.Get(metricName); found {
+		return time.Since(lastOKTime.(time.Time))
+	}
+	// Never been OK? This can happen; metric is bad ever since freno started running.
+	// There is no correct value to return here; we return a negative value to indicate "strange" or "Unknown"
+	return -time.Hour
 }
 
 func (throttler *Throttler) AppRequestMetricResult(appName string, metricResultFunc base.MetricResultFunc) (metricResult base.MetricResult, threshold float64) {

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -383,13 +383,11 @@ func (throttler *Throttler) markMetricHealthy(metricName string) {
 }
 
 // timeSinceMetricHealthy returns time elapsed since the last time a metric checked "OK"
-func (throttler *Throttler) timeSinceMetricHealthy(metricName string) time.Duration {
+func (throttler *Throttler) timeSinceMetricHealthy(metricName string) (timeSinceHealthy time.Duration, found bool) {
 	if lastOKTime, found := throttler.metricsHealth.Get(metricName); found {
-		return time.Since(lastOKTime.(time.Time))
+		return time.Since(lastOKTime.(time.Time)), true
 	}
-	// Never been OK? This can happen; metric is bad ever since freno started running.
-	// There is no correct value to return here; we return a negative value to indicate "strange" or "Unknown"
-	return -time.Hour
+	return 0, false
 }
 
 func (throttler *Throttler) metricsHealthSnapshot() map[string](*base.MetricHealth) {


### PR DESCRIPTION
This PR takes advantage of the fact `freno` runs self-checks via the special `freno` app name, iterating on all aggregated metrics.

It marks the last-known-time where a metric was checked to be "OK".

With this PR we generate metrics (i.e. a _gauge_) that tells the elapsed seconds since a given metric was "OK".

This is useful for setting up alerts on a metric that hasn't been OK in a long time.

- [x] TODO: add an API endpoint to expose this info.