### PR TITLE
Take into account mysqlCollectionInterval when performing checks

### DIFF
--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"fmt"
+
 	"github.com/github/freno/go/base"
 	metrics "github.com/rcrowley/go-metrics"
 )
@@ -28,7 +29,7 @@ func NewThrottlerCheck(throttler *Throttler) *ThrottlerCheck {
 func (check *ThrottlerCheck) checkAppMetricResult(appName string, metricResultFunc base.MetricResultFunc, overrideThreshold float64) (checkResult *CheckResult) {
 	metricResult, threshold := check.throttler.AppRequestMetricResult(appName, metricResultFunc)
 	if overrideThreshold > 0 {
-		threshold = overrideThreshold
+		threshold = overrideThreshold - float64(mysqlCollectInterval/time.Second)
 	}
 	value, err := metricResult.Get()
 	if appName == "" {


### PR DESCRIPTION
Currently, metrics are collected each `throttle.mysqlCollectInterval` units of time.

This PR modifies `ThrottlerCheck.checkAppMetricResult` to take that collection interval into account.

I'm also wondering if we should lower the interval at which we do collect the metrics. 

cc @shlomi-noach for 👀 