### PR TITLE
support MemcachePath, key prefix ; added memcache documentation

### DIFF
--- a/doc/clients.md
+++ b/doc/clients.md
@@ -11,6 +11,8 @@ Clients can be expected to issue many requests per second. `freno` is lightweigh
 
 It makes sense to hit `freno` in the whereabouts of the granularity one is looking at. If your client is to throttle on a `1000ms` replication lag, checking `freno` `200` times per sec may be overdoing it. However if you wish to keep your clients naive and without caching this should be fine.
 
+It is also possible to ask `freno` to write metrics to [memcache](memcache.md), in which case clients can read metrics directly using their favorite `memcache` client.
+
 # Usage samples
 
 

--- a/doc/memcache.md
+++ b/doc/memcache.md
@@ -1,0 +1,39 @@
+# Memcache
+
+`freno` can be instructed to write aggregated metrics to `memcache`. This allows clients to get data directly from `memcached` without even hitting `freno` HTTP. This, in turn, decouples read load from `freno`.
+
+Instruct `freno` to write aggregated metrics to `memcache` via `MemcacheServers` in the [config file](../resources/freno.conf.sample.json). List all `memcache` servers like so:
+
+```json
+{
+  "MemcacheServers": [
+    "memcache.server.one:11211",
+    "memcache.server.two:11211",
+    "memcache.server.three:11211"
+  ],
+}
+```
+
+Optionally set `MemcachePath` (default is `"freno"`):
+```json
+{
+  "MemcacheServers": [
+    "memcache.server.one:11211",
+    "memcache.server.two:11211",
+    "memcache.server.three:11211"
+  ],
+  "MemcachePath": "freno-production",
+}
+```
+
+
+### Memcache entries
+
+`freno` will write entries to memcache as follows:
+
+- The key will be of the form `<prefix>/<store-type>/<store-name>`
+  - `<prefix>` can be set via the `MemcachePath`, and defaults to `freno`
+  - An example key might be `freno/mysql/main1`
+- The value will be of the form `<epochmillis>:<aggregated-value>`.
+  - As example, it might be `1497418678836:0.54` where `1497418678836` is the unix epoch in milliseconds, and `0.54` is the aggregated value.
+  - Embedding the epoch within the value allows the app to double-check the validity of the value, or go into more granular validation.

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -93,6 +93,7 @@ type ConfigurationSettings struct {
 	DefaultRaftPort int      // if a RaftNodes entry does not specify port, use this one
 	RaftNodes       []string // Raft nodes to make initial connection with
 	MemcacheServers []string // if given, freno will report to aggregated values to given memcache
+	MemcachePath    string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
 	Stores          StoresSettings
 }
 

--- a/resources/freno.conf.sample.json
+++ b/resources/freno.conf.sample.json
@@ -4,6 +4,7 @@
   "RaftDataDir": "/var/lib/freno",
   "RaftBind": "10.0.0.1",
   "RaftNodes": ["10.0.0.1", "10.0.0.2", "10.0.0.3"],
+  "MemcacheServers": [],
   "Stores": {
     "MySQL": {
       "User": "${mysql_user_env_variable}",


### PR DESCRIPTION
Followup on https://github.com/github/freno/pull/46:

- Adding `MemcachePath` config variable, defaulting `"freno"` as memcache key prefix
- Added memcache documentation.