### PR TITLE
Build using and requires go1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.8
+go: 1.9
 
 os:
   - linux

--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ function precheck() {
   fi
 
   if [[ $(go version | egrep "go1[.][012345678]") ]]; then
-    echo "go version is too low. Must use 1.8 or above"
+    echo "go version is too low. Must use 1.9 or above"
     ok=1
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -72,8 +72,8 @@ function precheck() {
     ok=1
   fi
 
-  if [[ $(go version | egrep "go1[.][0123456]") ]]; then
-    echo "go version is too low. Must use 1.7 or above"
+  if [[ $(go version | egrep "go1[.][012345678]") ]]; then
+    echo "go version is too low. Must use 1.8 or above"
     ok=1
   fi
 

--- a/script/ensure-go-installed
+++ b/script/ensure-go-installed
@@ -1,19 +1,20 @@
 #!/bin/bash
 
-GO_VERSION=go1.7
+PREFERRED_GO_VERSION=go1.9.2
+SUPPORTED_GO_VERSIONS='go1.[89]'
 
-GO_PKG_DARWIN=${GO_VERSION}.darwin-amd64.pkg
-GO_PKG_DARWIN_SHA=e7089843bc7148ffcc147759985b213604d22bb9fd19bd930b515aa981bf1b22
+GO_PKG_DARWIN=${PREFERRED_GO_VERSION}.darwin-amd64.pkg
+GO_PKG_DARWIN_SHA=73fd5840d55f5566d8db6c0ffdd187577e8ebe650c783f68bd27cbf95bde6743
 
-GO_PKG_LINUX=${GO_VERSION}.linux-amd64.tar.gz
-GO_PKG_LINUX_SHA=702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95
+GO_PKG_LINUX=${PREFERRED_GO_VERSION}.linux-amd64.tar.gz
+GO_PKG_LINUX_SHA=de874549d9a8d8d8062be05808509c09a88a248e77ec14eb77453530829ac02b
 
 export ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 cd $ROOTDIR
 
 # If Go isn't installed globally, setup environment variables for local install.
-if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
-  GODIR="$ROOTDIR/.vendor/go17"
+if [ -z "$(which go)" ] || [ -z "$(go version | grep "$SUPPORTED_GO_VERSIONS")" ]; then
+  GODIR="$ROOTDIR/.vendor/go19"
 
   if [ $(uname -s) = "Darwin" ]; then
     export GOROOT="$GODIR/usr/local/go"
@@ -25,7 +26,7 @@ if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
 fi
 
 # Check if local install exists, and install otherwise.
-if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
+if [ -z "$(which go)" ] || [ -z "$(go version | grep "$SUPPORTED_GO_VERSIONS")" ]; then
   [ -d "$GODIR" ] && rm -rf $GODIR
   mkdir -p "$GODIR"
   cd "$GODIR";
@@ -42,7 +43,9 @@ if [ -z "$(which go)" ] || [ -z "$(go version | grep $GO_VERSION)" ]; then
   fi
 
   # Prove we did something right
-  echo "$GO_VERSION installed in $GODIR: Go Binary: $(which go)"
+  echo "$(go version) installed in $GODIR: Go Binary: $(which go)"
+else
+  echo "$(go version) found in $GODIR: Go Binary: $(which go)"
 fi
 
 cd $ROOTDIR


### PR DESCRIPTION
While still allowing `1.8`, we are moving towards `1.9`. I'd in particular like to use [Test Helper functions](https://golang.org/doc/go1.9#test-helper).