### PR TITLE
adding raft.is_healthy metric

### DIFF
--- a/go/group/raft.go
+++ b/go/group/raft.go
@@ -92,13 +92,24 @@ func Monitor() {
 			}
 			leaderExpVar.(*expvar.String).Set(leaderHint)
 
-			if IsLeader() {
+			state := GetState()
+			if state == raft.Leader {
 				leaderHint = fmt.Sprintf("%s (this host)", leaderHint)
 				metrics.GetOrRegisterGauge("raft.is_leader", nil).Update(1)
 			} else {
 				metrics.GetOrRegisterGauge("raft.is_leader", nil).Update(0)
 			}
-			log.Debugf("raft leader is %s; state: %s", leaderHint, GetState().String())
+			switch state {
+			case raft.Leader, raft.Follower:
+				{
+					metrics.GetOrRegisterGauge("raft.is_healthy", nil).Update(1)
+				}
+			default:
+				{
+					metrics.GetOrRegisterGauge("raft.is_healthy", nil).Update(0)
+				}
+			}
+			log.Debugf("raft leader is %s; state: %s", leaderHint, state.String())
 		}
 	}
 }


### PR DESCRIPTION
`raft.is_healthy` will be advertised in `/debug/metrics`

`raft.is_healthy` is `true` when the node is either the `Leader` or a `Follower`.
