### PR TITLE
More frequent local checks

### DIFF
--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -11,7 +11,7 @@ import (
 )
 
 const frenoAppName = "freno"
-const selfCheckInterval = 5 * time.Second
+const selfCheckInterval = 500 * time.Millisecond
 
 // ThrottlerCheck provides methdos for an app checking on metrics
 type ThrottlerCheck struct {

--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"fmt"
+
 	"github.com/github/freno/go/base"
 	metrics "github.com/rcrowley/go-metrics"
 )
 
 const frenoAppName = "freno"
-const selfCheckInterval = 500 * time.Millisecond
+const selfCheckInterval = 1 * time.Second
 
 // ThrottlerCheck provides methdos for an app checking on metrics
 type ThrottlerCheck struct {


### PR DESCRIPTION
Local checks running at `5s` intervals are at very low resolution. Local checks are susceptible to failure when an aggressive operation is running. With such low resolution of `5s` it is plausible that multiple successive self checks in a row will all fail.

This PR reduces interval to `500ms`, which reduces the probability for health check failure.

cc @github/database-infrastructure 