### PR TITLE
Simpler and more lightweight leader check

### DIFF
--- a/go/group/raft.go
+++ b/go/group/raft.go
@@ -61,9 +61,7 @@ func normalizeRaftNode(node string) string {
 
 // IsLeader tells if this node is the current raft leader
 func IsLeader() bool {
-	future := getRaft().VerifyLeader()
-	err := future.Error()
-	return err == nil
+	return GetState() == raft.Leader
 }
 
 // GetLeader returns identity of raft leader


### PR DESCRIPTION
In this PR the leader check does not run a synchronous operation, but relies on the `State` variables (same thing done with `orchestrator`).