### PR TITLE
support for CacheMillis: caching of metric result

### DIFF
--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -14,6 +14,7 @@ type MySQLClusterConfigurationSettings struct {
 	User              string  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	Password          string  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	MetricQuery       string  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	CacheMillis       int     // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	ThrottleThreshold float64 // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	Port              int     // Specify if different than 3306 or if different than specified by MySQLConfigurationSettings
 	IgnoreHostsCount  int     // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
@@ -40,6 +41,7 @@ type MySQLConfigurationSettings struct {
 	User              string
 	Password          string
 	MetricQuery       string
+	CacheMillis       int // optional, if defined then probe result will be cached, and future probes may use cached value
 	ThrottleThreshold float64
 	Port              int // Specify if different than 3306; applies to all clusters
 	IgnoreHostsCount  int // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
@@ -74,6 +76,9 @@ func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
 		}
 		if clusterSettings.MetricQuery == "" {
 			clusterSettings.MetricQuery = settings.MetricQuery
+		}
+		if clusterSettings.CacheMillis == 0 {
+			clusterSettings.CacheMillis = settings.CacheMillis
 		}
 		if clusterSettings.ThrottleThreshold == 0 {
 			clusterSettings.ThrottleThreshold = settings.ThrottleThreshold

--- a/go/mysql/probe.go
+++ b/go/mysql/probe.go
@@ -20,6 +20,7 @@ type Probe struct {
 	User        string
 	Password    string
 	MetricQuery string
+	CacheMillis int
 	InProgress  int64
 }
 

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -186,6 +186,7 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 			User:        clusterSettings.User,
 			Password:    clusterSettings.Password,
 			MetricQuery: clusterSettings.MetricQuery,
+			CacheMillis: clusterSettings.CacheMillis,
 		}
 		(*probes)[*key] = probe
 	}


### PR DESCRIPTION
Supporting `CacheMillis` in configuration, e.g.:

```
"Clusters": {
  "local": {
    "MetricQuery": "select rand()*1000",
    "CacheMillis": 5000,
  }
}
```

`CacheMillis` is supported in global `MySQL` config or in per-cluster config.

MySQL metrics are being polled every `100ms` (potentially we will drop down to a `50ms` interval).
For some queries it makes absolute sense to run at that interval ; for others it doesn't.

`CacheMillis` will make probing cache the result for designated time (`0` == no cache). With `CacheMillis > 0` the backend MySQL servers will see less queries. `freno` will continue to run the probes, internally, at `100ms` interval, but most of these will hit the internal cache and never reach MySQL.

An example of such metric that doesn't make sense to run 10 times per sec: reading history length on a master.

cc @github/database-infrastructure 