### PR TITLE
API: check-if-exists: return OK if metric does not exist

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -151,10 +151,8 @@ func (api *APIImpl) check(w http.ResponseWriter, r *http.Request, ps httprouter.
 	}
 
 	checkResult := api.throttlerCheck.Check(appName, storeType, storeName, remoteAddr, overrideThreshold)
-	if okIfNotExists {
-		if checkResult.StatusCode == http.StatusNotFound {
-			checkResult.StatusCode = http.StatusOK // 200
-		}
+	if checkResult.StatusCode == http.StatusNotFound && okIfNotExists {
+		checkResult.StatusCode = http.StatusOK // 200
 	}
 
 	api.respondToCheckRequest(w, r, checkResult)


### PR DESCRIPTION
This PR adds a new type of check: `/check-if-exists/:app/:storeType/:storeName`

The API is identical to the `/check` test, except this check supports _optional metrics_. If the metric exists, then a threshold check is made as usual. But if the metric does not exist, the check returns with HTTP OK (200).

This is useful where we may have special tests for particular clusters. For example, all tests throttle on replication lag, and some other tests can throttle on master metrics, if such metrics are being collected and monitored by `freno`.

cc @github/database-infrastructure 