### PR TITLE
HTTP checks for MySQL

### DIFF
--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -38,6 +38,8 @@ You will find the top-level configuration:
   "CacheMillis": 0,
   "ThrottleThreshold": 1.0,
   "IgnoreHostsCount": 0,
+  "HttpCheckPort": -1,
+  "HttpCheckPath": "path-to-check",
   "Clusters": {
   }
 }
@@ -57,6 +59,13 @@ These params apply in general to all MySQL clusters, unless specified differentl
   - Note: valid range is `[0..)` (`0` or more), where lower values are stricter and higher values are more permissive.
   - Note: use _seconds_ as replication lag time unit. In the above we throttle above `1.0` seconds.
 - `IgnoreHostsCount`: number of hosts that can be ignored while aggregating cluster's values. For example, if `IgnoreHostsCount` is `2`, then up to `2` hosts that have errors are silently ignored. Or, if there's no errors, the two highest values will be ignored (so if these two values exceed the cluster's threshold, `freno` may still be happy to allow writes to the cluster).
+- `HttpCheckPort`: when `> 0`, and together with `HttpCheckPath`, `freno` will run a HTTP check on the MySQL boxes. For a given cluster there can only be one HTTP check on a MySQL box, even if one has multiple MySQL services running on that box.
+  The HTTP check may return any HTTP status. The `404 Not Found` status is special: `freno` will completely disregard hosts where HTTP checks return `404`.
+
+  You may override `HttpCheckPort` on specific clusters. Set to `-1` to disable HTTP check.
+- `HttpCheckPath`: path to test. e.g. when `"HttpCheckPort": 1234` and `"HttpCheckPath": "health"`, `freno` will test `http://<mysql-box>:1234/health`.
+
+  You may override `HttpCheckPath` on specific clusters.
 
 Looking at clusters configuration:
 

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -18,6 +18,8 @@ type MySQLClusterConfigurationSettings struct {
 	ThrottleThreshold float64 // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 	Port              int     // Specify if different than 3306 or if different than specified by MySQLConfigurationSettings
 	IgnoreHostsCount  int     // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	HttpCheckPort     int     // Specify if different than specified by MySQLConfigurationSettings. -1 to disable HTTP check
+	HttpCheckPath     string  //  Specify if different than specified by MySQLConfigurationSettings
 
 	HAProxySettings     HAProxyConfigurationSettings // If list of servers is to be acquired via HAProxy, provide this field
 	StaticHostsSettings StaticHostsConfigurationSettings
@@ -43,8 +45,10 @@ type MySQLConfigurationSettings struct {
 	MetricQuery       string
 	CacheMillis       int // optional, if defined then probe result will be cached, and future probes may use cached value
 	ThrottleThreshold float64
-	Port              int // Specify if different than 3306; applies to all clusters
-	IgnoreHostsCount  int // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	Port              int    // Specify if different than 3306; applies to all clusters
+	IgnoreHostsCount  int    // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	HttpCheckPort     int    // port for HTTP check. -1 to disable.
+	HttpCheckPath     string // If non-empty, requires HttpCheckPort
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }
@@ -88,6 +92,12 @@ func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
 		}
 		if clusterSettings.IgnoreHostsCount == 0 {
 			clusterSettings.IgnoreHostsCount = settings.IgnoreHostsCount
+		}
+		if clusterSettings.HttpCheckPort == 0 {
+			clusterSettings.HttpCheckPort = settings.HttpCheckPort
+		}
+		if clusterSettings.HttpCheckPath == "" {
+			clusterSettings.HttpCheckPath = settings.HttpCheckPath
 		}
 	}
 	return nil

--- a/go/mysql/mysql_http_check.go
+++ b/go/mysql/mysql_http_check.go
@@ -1,0 +1,35 @@
+/*
+   Copyright 2018 GitHub Inc.
+	 See https://github.com/github/freno/blob/master/LICENSE
+*/
+
+package mysql
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type MySQLHttpCheck struct {
+	Key         InstanceKey
+	CheckResult int
+}
+
+func NewMySQLHttpCheck(instanceKey *InstanceKey, checkResult int) *MySQLHttpCheck {
+	return &MySQLHttpCheck{
+		Key:         *instanceKey,
+		CheckResult: checkResult,
+	}
+}
+
+func CheckHttp(probe *Probe) (httpCheckResult *MySQLHttpCheck) {
+	if probe.HttpCheckPort < 0 {
+		return NewMySQLHttpCheck(&probe.Key, http.StatusOK)
+	}
+	url := fmt.Sprintf("%s:%d/%s", probe.Key.Hostname, probe.HttpCheckPort, probe.HttpCheckPath)
+	resp, err := http.Get(url)
+	if err != nil {
+		return NewMySQLHttpCheck(&probe.Key, http.StatusInternalServerError)
+	}
+	return NewMySQLHttpCheck(&probe.Key, resp.StatusCode)
+}

--- a/go/mysql/mysql_http_check.go
+++ b/go/mysql/mysql_http_check.go
@@ -35,7 +35,7 @@ func CheckHttp(probe *Probe) (httpCheckResult *MySQLHttpCheck) {
 		go func() { metrics.GetOrRegisterCounter("httpcheck.skip", nil).Inc(1) }()
 		return NewMySQLHttpCheck(&probe.Key, http.StatusOK)
 	}
-	url := fmt.Sprintf("%s:%d/%s", probe.Key.Hostname, probe.HttpCheckPort, probe.HttpCheckPath)
+	url := fmt.Sprintf("http://%s:%d/%s", probe.Key.Hostname, probe.HttpCheckPort, probe.HttpCheckPath)
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		go func() { metrics.GetOrRegisterCounter("httpcheck.error", nil).Inc(1) }()

--- a/go/mysql/mysql_http_check.go
+++ b/go/mysql/mysql_http_check.go
@@ -18,29 +18,39 @@ var httpClient = http.Client{
 }
 
 type MySQLHttpCheck struct {
+	ClusterName string
 	Key         InstanceKey
 	CheckResult int
 }
 
-func NewMySQLHttpCheck(instanceKey *InstanceKey, checkResult int) *MySQLHttpCheck {
+func NewMySQLHttpCheck(clusterName string, instanceKey *InstanceKey, checkResult int) *MySQLHttpCheck {
 	return &MySQLHttpCheck{
+		ClusterName: clusterName,
 		Key:         *instanceKey,
 		CheckResult: checkResult,
 	}
 }
 
-func CheckHttp(probe *Probe) (httpCheckResult *MySQLHttpCheck) {
+func (check *MySQLHttpCheck) HashKey() string {
+	return MySQLHttpCheckHashKey(check.ClusterName, &check.Key)
+}
+
+func MySQLHttpCheckHashKey(clusterName string, key *InstanceKey) string {
+	return fmt.Sprintf("%s:%s", clusterName, key.StringCode())
+}
+
+func CheckHttp(clusterName string, probe *Probe) (httpCheckResult *MySQLHttpCheck) {
 
 	if probe.HttpCheckPort < 0 {
 		go func() { metrics.GetOrRegisterCounter("httpcheck.skip", nil).Inc(1) }()
-		return NewMySQLHttpCheck(&probe.Key, http.StatusOK)
+		return NewMySQLHttpCheck(clusterName, &probe.Key, http.StatusOK)
 	}
 	url := fmt.Sprintf("http://%s:%d/%s", probe.Key.Hostname, probe.HttpCheckPort, probe.HttpCheckPath)
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		go func() { metrics.GetOrRegisterCounter("httpcheck.error", nil).Inc(1) }()
-		return NewMySQLHttpCheck(&probe.Key, http.StatusInternalServerError)
+		return NewMySQLHttpCheck(clusterName, &probe.Key, http.StatusInternalServerError)
 	}
 	go func() { metrics.GetOrRegisterCounter(fmt.Sprintf("httpcheck.%d", resp.StatusCode), nil).Inc(1) }()
-	return NewMySQLHttpCheck(&probe.Key, resp.StatusCode)
+	return NewMySQLHttpCheck(clusterName, &probe.Key, resp.StatusCode)
 }

--- a/go/mysql/mysql_http_check.go
+++ b/go/mysql/mysql_http_check.go
@@ -41,7 +41,7 @@ func MySQLHttpCheckHashKey(clusterName string, key *InstanceKey) string {
 
 func CheckHttp(clusterName string, probe *Probe) (httpCheckResult *MySQLHttpCheck) {
 
-	if probe.HttpCheckPort < 0 {
+	if probe.HttpCheckPort <= 0 {
 		go func() { metrics.GetOrRegisterCounter("httpcheck.skip", nil).Inc(1) }()
 		return NewMySQLHttpCheck(clusterName, &probe.Key, http.StatusOK)
 	}

--- a/go/mysql/mysql_inventory.go
+++ b/go/mysql/mysql_inventory.go
@@ -10,21 +10,21 @@ import (
 )
 
 type InstanceMetricResultMap map[InstanceKey]base.MetricResult
-type InstanceHttpCheckResultMap map[InstanceKey]int
+type ClusterInstanceHttpCheckResultMap map[string]int
 
 type MySQLInventory struct {
-	ClustersProbes        map[string](*Probes)
-	IgnoreHostsCount      map[string]int
-	InstanceKeyMetrics    InstanceMetricResultMap
-	InstanceKeyHttpChecks InstanceHttpCheckResultMap
+	ClustersProbes            map[string](*Probes)
+	IgnoreHostsCount          map[string]int
+	InstanceKeyMetrics        InstanceMetricResultMap
+	ClusterInstanceHttpChecks ClusterInstanceHttpCheckResultMap
 }
 
 func NewMySQLInventory() *MySQLInventory {
 	inventory := &MySQLInventory{
-		ClustersProbes:        make(map[string](*Probes)),
-		IgnoreHostsCount:      make(map[string]int),
-		InstanceKeyMetrics:    make(map[InstanceKey]base.MetricResult),
-		InstanceKeyHttpChecks: make(map[InstanceKey]int),
+		ClustersProbes:            make(map[string](*Probes)),
+		IgnoreHostsCount:          make(map[string]int),
+		InstanceKeyMetrics:        make(map[InstanceKey]base.MetricResult),
+		ClusterInstanceHttpChecks: make(map[string]int),
 	}
 	return inventory
 }

--- a/go/mysql/mysql_inventory.go
+++ b/go/mysql/mysql_inventory.go
@@ -10,18 +10,21 @@ import (
 )
 
 type InstanceMetricResultMap map[InstanceKey]base.MetricResult
+type InstanceHttpCheckResultMap map[InstanceKey]int
 
 type MySQLInventory struct {
-	ClustersProbes     map[string](*Probes)
-	IgnoreHostsCount   map[string]int
-	InstanceKeyMetrics InstanceMetricResultMap
+	ClustersProbes        map[string](*Probes)
+	IgnoreHostsCount      map[string]int
+	InstanceKeyMetrics    InstanceMetricResultMap
+	InstanceKeyHttpChecks InstanceHttpCheckResultMap
 }
 
 func NewMySQLInventory() *MySQLInventory {
 	inventory := &MySQLInventory{
-		ClustersProbes:     make(map[string](*Probes)),
-		IgnoreHostsCount:   make(map[string]int),
-		InstanceKeyMetrics: make(map[InstanceKey]base.MetricResult),
+		ClustersProbes:        make(map[string](*Probes)),
+		IgnoreHostsCount:      make(map[string]int),
+		InstanceKeyMetrics:    make(map[InstanceKey]base.MetricResult),
+		InstanceKeyHttpChecks: make(map[InstanceKey]int),
 	}
 	return inventory
 }

--- a/go/mysql/probe.go
+++ b/go/mysql/probe.go
@@ -16,12 +16,15 @@ const timeoutMillis = 1000
 
 // Probe is the minimal configuration required to connect to a MySQL server
 type Probe struct {
-	Key         InstanceKey
-	User        string
-	Password    string
-	MetricQuery string
-	CacheMillis int
-	InProgress  int64
+	Key                 InstanceKey
+	User                string
+	Password            string
+	MetricQuery         string
+	CacheMillis         int
+	QueryInProgress     int64
+	HttpCheckPort       int
+	HttpCheckPath       string
+	HttpCheckInProgress int64
 }
 
 type Probes map[InstanceKey](*Probe)

--- a/go/throttle/mysql.go
+++ b/go/throttle/mysql.go
@@ -8,12 +8,12 @@ import (
 	"github.com/github/freno/go/mysql"
 )
 
-func aggregateMySQLProbes(probes *mysql.Probes, instanceResultsMap mysql.InstanceMetricResultMap, instanceHttpChecksMap mysql.InstanceHttpCheckResultMap, ignoreHostsCount int) (worstMetric base.MetricResult) {
+func aggregateMySQLProbes(probes *mysql.Probes, clusterName string, instanceResultsMap mysql.InstanceMetricResultMap, clusterInstanceHttpChecksMap mysql.ClusterInstanceHttpCheckResultMap, ignoreHostsCount int) (worstMetric base.MetricResult) {
 	// probes is known not to change. It can be *replaced*, but not changed.
 	// so it's safe to iterate it
 	probeValues := []float64{}
 	for _, probe := range *probes {
-		if instanceHttpChecksMap[probe.Key] == http.StatusNotFound {
+		if clusterInstanceHttpChecksMap[mysql.MySQLHttpCheckHashKey(clusterName, &probe.Key)] == http.StatusNotFound {
 			continue
 		}
 		instanceMetricResult, ok := instanceResultsMap[probe.Key]

--- a/go/throttle/mysql.go
+++ b/go/throttle/mysql.go
@@ -11,15 +11,6 @@ import (
 func aggregateMySQLProbes(probes *mysql.Probes, instanceResultsMap mysql.InstanceMetricResultMap, instanceHttpChecksMap mysql.InstanceHttpCheckResultMap, ignoreHostsCount int) (worstMetric base.MetricResult) {
 	// probes is known not to change. It can be *replaced*, but not changed.
 	// so it's safe to iterate it
-	availableProbes := len(*probes)
-	for _, probe := range *probes {
-		if instanceHttpChecksMap[probe.Key] == http.StatusNotFound {
-			availableProbes--
-		}
-	}
-	if availableProbes == 0 {
-		return base.NoHostsMetricResult
-	}
 	probeValues := []float64{}
 	for _, probe := range *probes {
 		if instanceHttpChecksMap[probe.Key] == http.StatusNotFound {
@@ -43,6 +34,10 @@ func aggregateMySQLProbes(probes *mysql.Probes, instanceResultsMap mysql.Instanc
 		// No error
 		probeValues = append(probeValues, value)
 	}
+	if len(probeValues) == 0 {
+		return base.NoHostsMetricResult
+	}
+
 	// If we got here, that means no errors (or good to skip errors)
 	sort.Float64s(probeValues)
 	for ignoreHostsCount > 0 {

--- a/go/throttle/mysql_test.go
+++ b/go/throttle/mysql_test.go
@@ -6,6 +6,7 @@
 package throttle
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/github/freno/go/base"
@@ -35,42 +36,49 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 		key4: base.NewSimpleMetricResult(0.6),
 		key5: base.NewSimpleMetricResult(1.1),
 	}
+	instanceHttpCheckResultMap := mysql.InstanceHttpCheckResultMap{
+		key1: http.StatusOK,
+		key2: http.StatusOK,
+		key3: http.StatusOK,
+		key4: http.StatusOK,
+		key5: http.StatusOK,
+	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
 	for key := range instanceResultsMap {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 1)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 2)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.1)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 3)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 3)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.6)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 4)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 4)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 5)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 5)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
@@ -85,24 +93,31 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 		key4: base.NoSuchMetric,
 		key5: base.NewSimpleMetricResult(1.1),
 	}
+	instanceHttpCheckResultMap := mysql.InstanceHttpCheckResultMap{
+		key1: http.StatusOK,
+		key2: http.StatusOK,
+		key3: http.StatusOK,
+		key4: http.StatusOK,
+		key5: http.StatusOK,
+	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
 	for key := range instanceResultsMap {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 1)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 2)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
@@ -110,19 +125,19 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 
 	instanceResultsMap[key1] = base.NoSuchMetric
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 1)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 2)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)

--- a/go/throttle/mysql_test.go
+++ b/go/throttle/mysql_test.go
@@ -29,6 +29,7 @@ func init() {
 }
 
 func TestAggregateMySQLProbesNoErrors(t *testing.T) {
+	clusterName := "c0"
 	instanceResultsMap := mysql.InstanceMetricResultMap{
 		key1: base.NewSimpleMetricResult(1.2),
 		key2: base.NewSimpleMetricResult(1.7),
@@ -36,49 +37,49 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 		key4: base.NewSimpleMetricResult(0.6),
 		key5: base.NewSimpleMetricResult(1.1),
 	}
-	instanceHttpCheckResultMap := mysql.InstanceHttpCheckResultMap{
-		key1: http.StatusOK,
-		key2: http.StatusOK,
-		key3: http.StatusOK,
-		key4: http.StatusOK,
-		key5: http.StatusOK,
+	clusterInstanceHttpCheckResultMap := mysql.ClusterInstanceHttpCheckResultMap{
+		mysql.MySQLHttpCheckHashKey(clusterName, &key1): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key2): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key3): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key4): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key5): http.StatusOK,
 	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
 	for key := range instanceResultsMap {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.1)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 3)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 3)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.6)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 4)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 4)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 5)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 5)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
@@ -86,6 +87,7 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 }
 
 func TestAggregateMySQLProbesWithErrors(t *testing.T) {
+	clusterName := "c0"
 	instanceResultsMap := mysql.InstanceMetricResultMap{
 		key1: base.NewSimpleMetricResult(1.2),
 		key2: base.NewSimpleMetricResult(1.7),
@@ -93,31 +95,31 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 		key4: base.NoSuchMetric,
 		key5: base.NewSimpleMetricResult(1.1),
 	}
-	instanceHttpCheckResultMap := mysql.InstanceHttpCheckResultMap{
-		key1: http.StatusOK,
-		key2: http.StatusOK,
-		key3: http.StatusOK,
-		key4: http.StatusOK,
-		key5: http.StatusOK,
+	clusterInstanceHttpCheckResultMap := mysql.ClusterInstanceHttpCheckResultMap{
+		mysql.MySQLHttpCheckHashKey(clusterName, &key1): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key2): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key3): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key4): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key5): http.StatusOK,
 	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
 	for key := range instanceResultsMap {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
@@ -125,19 +127,19 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 
 	instanceResultsMap[key1] = base.NoSuchMetric
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
@@ -145,6 +147,7 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 }
 
 func TestAggregateMySQLProbesWithHttpChecks(t *testing.T) {
+	clusterName := "c0"
 	instanceResultsMap := mysql.InstanceMetricResultMap{
 		key1: base.NewSimpleMetricResult(1.2),
 		key2: base.NewSimpleMetricResult(1.7),
@@ -152,34 +155,34 @@ func TestAggregateMySQLProbesWithHttpChecks(t *testing.T) {
 		key4: base.NoSuchMetric,
 		key5: base.NewSimpleMetricResult(1.1),
 	}
-	instanceHttpCheckResultMap := mysql.InstanceHttpCheckResultMap{
-		key1: http.StatusOK,
-		key2: http.StatusOK,
-		key3: http.StatusOK,
-		key4: http.StatusNotFound,
-		key5: http.StatusOK,
+	clusterInstanceHttpCheckResultMap := mysql.ClusterInstanceHttpCheckResultMap{
+		mysql.MySQLHttpCheckHashKey(clusterName, &key1): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key2): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key3): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key4): http.StatusNotFound,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key5): http.StatusOK,
 	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
 	for key := range instanceResultsMap {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 	}
 	{
-		instanceHttpCheckResultMap[key2] = http.StatusNotFound
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 0)
+		clusterInstanceHttpCheckResultMap[mysql.MySQLHttpCheckHashKey(clusterName, &key2)] = http.StatusNotFound
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
 	}
 	{
-		for key := range instanceHttpCheckResultMap {
-			instanceHttpCheckResultMap[key] = http.StatusNotFound
+		for hashKey := range clusterInstanceHttpCheckResultMap {
+			clusterInstanceHttpCheckResultMap[hashKey] = http.StatusNotFound
 		}
-		worstMetric := aggregateMySQLProbes(&probes, instanceResultsMap, instanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 	}

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -24,6 +24,7 @@ const leaderCheckInterval = 1 * time.Second
 const mysqlCollectInterval = 100 * time.Millisecond
 const mysqlRefreshInterval = 10 * time.Second
 const mysqlAggreateInterval = 50 * time.Millisecond
+const mysqlHttpCheckInterval = 5 * time.Second
 
 const aggregatedMetricsExpiration = 5 * time.Second
 const aggregatedMetricsCleanup = 1 * time.Second
@@ -42,6 +43,7 @@ type Throttler struct {
 	isLeaderFunc func() bool
 
 	mysqlThrottleMetricChan chan *mysql.MySQLThrottleMetric
+	mysqlHttpCheckChan      chan *mysql.MySQLHttpCheck
 	mysqlInventoryChan      chan *mysql.MySQLInventory
 	mysqlClusterProbesChan  chan *mysql.ClusterProbes
 
@@ -65,6 +67,7 @@ func NewThrottler(isLeaderFunc func() bool) *Throttler {
 		isLeaderFunc: isLeaderFunc,
 
 		mysqlThrottleMetricChan: make(chan *mysql.MySQLThrottleMetric),
+		mysqlHttpCheckChan:      make(chan *mysql.MySQLHttpCheck),
 
 		mysqlInventoryChan:     make(chan *mysql.MySQLInventory, 1),
 		mysqlClusterProbesChan: make(chan *mysql.ClusterProbes),
@@ -94,6 +97,7 @@ func (throttler *Throttler) Operate() {
 	mysqlCollectTick := time.Tick(mysqlCollectInterval)
 	mysqlRefreshTick := time.Tick(mysqlRefreshInterval)
 	mysqlAggregateTick := time.Tick(mysqlAggreateInterval)
+	mysqlHttpCheckTick := time.Tick(mysqlHttpCheckInterval)
 	throttledAppsTick := time.Tick(throttledAppsSnapshotInterval)
 
 	// initial read of inventory:
@@ -111,10 +115,19 @@ func (throttler *Throttler) Operate() {
 				// frequent
 				throttler.collectMySQLMetrics()
 			}
+		case <-mysqlHttpCheckTick:
+			{
+				throttler.collectMySQLHttpChecks()
+			}
 		case metric := <-throttler.mysqlThrottleMetricChan:
 			{
 				// incoming MySQL metric, frequent, as result of collectMySQLMetrics()
 				throttler.mysqlInventory.InstanceKeyMetrics[metric.Key] = metric
+			}
+		case httpCheckResult := <-throttler.mysqlHttpCheckChan:
+			{
+				// incoming MySQL metric, frequent, as result of collectMySQLMetrics()
+				throttler.mysqlInventory.InstanceKeyHttpChecks[httpCheckResult.Key] = httpCheckResult.CheckResult
 			}
 		case <-mysqlRefreshTick:
 			{
@@ -157,12 +170,40 @@ func (throttler *Throttler) collectMySQLMetrics() error {
 				go func() {
 					// Avoid querying the same server twice at the same time. If previous read is still there,
 					// we avoid re-reading it.
-					if !atomic.CompareAndSwapInt64(&probe.InProgress, 0, 1) {
+					if !atomic.CompareAndSwapInt64(&probe.QueryInProgress, 0, 1) {
 						return
 					}
-					defer atomic.StoreInt64(&probe.InProgress, 0)
+					defer atomic.StoreInt64(&probe.QueryInProgress, 0)
 					throttleMetrics := mysql.ReadThrottleMetric(probe)
 					throttler.mysqlThrottleMetricChan <- throttleMetrics
+				}()
+			}
+		}()
+	}
+	return nil
+}
+
+func (throttler *Throttler) collectMySQLHttpChecks() error {
+	if !throttler.isLeader {
+		return nil
+	}
+	// synchronously, get lists of probes
+	for _, probes := range throttler.mysqlInventory.ClustersProbes {
+		probes := probes
+		go func() {
+			// probes is known not to change. It can be *replaced*, but not changed.
+			// so it's safe to iterate it
+			for _, probe := range *probes {
+				probe := probe
+				go func() {
+					// Avoid querying the same server twice at the same time. If previous read is still there,
+					// we avoid re-reading it.
+					if !atomic.CompareAndSwapInt64(&probe.HttpCheckInProgress, 0, 1) {
+						return
+					}
+					defer atomic.StoreInt64(&probe.HttpCheckInProgress, 0)
+					httpCheckResult := mysql.CheckHttp(probe)
+					throttler.mysqlHttpCheckChan <- httpCheckResult
 				}()
 			}
 		}()
@@ -182,11 +223,13 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 		log.Debugf("read instance key: %+v", key)
 
 		probe := &mysql.Probe{
-			Key:         *key,
-			User:        clusterSettings.User,
-			Password:    clusterSettings.Password,
-			MetricQuery: clusterSettings.MetricQuery,
-			CacheMillis: clusterSettings.CacheMillis,
+			Key:           *key,
+			User:          clusterSettings.User,
+			Password:      clusterSettings.Password,
+			MetricQuery:   clusterSettings.MetricQuery,
+			CacheMillis:   clusterSettings.CacheMillis,
+			HttpCheckPath: clusterSettings.HttpCheckPath,
+			HttpCheckPort: clusterSettings.HttpCheckPort,
 		}
 		(*probes)[*key] = probe
 	}
@@ -259,7 +302,7 @@ func (throttler *Throttler) aggregateMySQLMetrics() error {
 	for clusterName, probes := range throttler.mysqlInventory.ClustersProbes {
 		metricName := fmt.Sprintf("mysql/%s", clusterName)
 		ignoreHostsCount := throttler.mysqlInventory.IgnoreHostsCount[clusterName]
-		aggregatedMetric := aggregateMySQLProbes(probes, throttler.mysqlInventory.InstanceKeyMetrics, ignoreHostsCount)
+		aggregatedMetric := aggregateMySQLProbes(probes, throttler.mysqlInventory.InstanceKeyMetrics, throttler.mysqlInventory.InstanceKeyHttpChecks, ignoreHostsCount)
 		go throttler.aggregatedMetrics.Set(metricName, aggregatedMetric, cache.DefaultExpiration)
 		if throttler.memcacheClient != nil {
 			go func() {


### PR DESCRIPTION
In this PR `freno` is capable of running `HTTP` checks on MySQL nodes. This is similarly to how `HAProxy` runs checks, and in fact intends to replace HAProxy's checks (the original reason: HAProxy's inability to transition `DOWN`->`NOLB`, something we find very important).

cc @github/database-infrastructure 