### PR TITLE
Getting hosts from vitess API

### DIFF
--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -79,6 +79,12 @@ Looking at clusters configuration:
       "PoolName": "my_prod4_pool"
     }
   },
+  "sharded": {
+    "VitessSettings": {
+      "API": "https://vtctld.example.com/api/",
+      "Keyspace": "my_sharded_ks"
+    }
+  },
   "local": {
     "User": "msandbox",
     "Password": "msandbox",

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -22,6 +22,7 @@ type MySQLClusterConfigurationSettings struct {
 	HttpCheckPath     string  //  Specify if different than specified by MySQLConfigurationSettings
 
 	HAProxySettings     HAProxyConfigurationSettings // If list of servers is to be acquired via HAProxy, provide this field
+	VitessSettings      VitessConfigurationSettings  // If list of servers is to be acquired via Vitess, provide this field
 	StaticHostsSettings StaticHostsConfigurationSettings
 }
 

--- a/go/config/vitess_config.go
+++ b/go/config/vitess_config.go
@@ -1,0 +1,21 @@
+package config
+
+//
+// HAProxy-specific configuration
+//
+
+type VitessConfigurationSettings struct {
+	API      string
+	Keyspace string
+	Shard    string
+}
+
+func (settings *VitessConfigurationSettings) IsEmpty() bool {
+	if settings.API == "" {
+		return true
+	}
+	if settings.Keyspace == "" {
+		return true
+	}
+	return false
+}

--- a/go/vitess/api_client.go
+++ b/go/vitess/api_client.go
@@ -1,0 +1,49 @@
+package vitess
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Tablet represents information about a running instance of vttablet.
+type Tablet struct {
+	MysqlHostname string `json:"mysql_hostname,omitempty"`
+	MysqlPort     int32  `json:"mysql_port,omitempty"`
+}
+
+var httpClient = http.Client{
+	Timeout: 1 * time.Second,
+}
+
+func constructAPIURL(api string, keyspace string, shard string) (url string) {
+	api = strings.TrimRight(api, "/")
+	if !strings.HasSuffix(api, "/api") {
+		api = fmt.Sprintf("%s/api", api)
+	}
+	url = fmt.Sprintf("%s/ks_tablets/%s/%s", api, keyspace, shard)
+
+	return url
+}
+
+// ParseTablets reads from vitess /api/ks_tablets/<keyspace>/[shard] and returns a
+// tblet (mysql_hostname, mysql_port) listing
+func ParseTablets(api string, keyspace string, shard string) (tablets []Tablet, err error) {
+	url := constructAPIURL(api, keyspace, shard)
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return tablets, err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return tablets, err
+	}
+
+	err = json.Unmarshal(body, &tablets)
+	return tablets, err
+}


### PR DESCRIPTION
This PR supports extracting list of hosts from Vitess's `vtctld` API.

It uses a `api/ks_tablets` endpoint, which is not (yet?) present in upstream. It supports specifying a shard, if desired, or it supports not specifying a shard, in which case all shards are considered.
