### PR TITLE
meta checks: aggregating multiple checks under a single alias

### DIFF
--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -133,4 +133,22 @@ Noteworthy:
 
 `freno` explicitly recognizes `show global ...` statements and reads the result's numeric value.
 
-Otherwise you may provide any query that returns a single row, single numeric column.
+Otherwise you may provide any query that returns a single row, single numeric column. As another example, consider this query to identify the history length on a master:
+
+```json
+"Clusters": {
+  "cluster8-writer": {
+    "MetricQuery": "SELECT count FROM information_schema.innodb_metrics WHERE name = 'trx_rseg_history_len'",
+    "CacheMillis": 1000,
+    "ThrottleThreshold": 100000,
+    "IgnoreHostsCount": 0,
+    "User": "msandbox",
+    "Password": "msandbox",
+    "HAProxySettings": {
+      "Host": "my.haproxy.mydomain.com",
+      "Port": 2001,
+      "PoolName": "my_prod8_writer"
+    }
+  }
+}
+```

--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -152,3 +152,50 @@ Otherwise you may provide any query that returns a single row, single numeric co
   }
 }
 ```
+
+### Meta checks
+
+You may also define _meta checks_ that aggregate multiple other checks. With a single API call on a meta-check you will implicitly invoke multiple other checks. A meta-check only responds with `HTTP 200 OK` when all aggregated checks return the same.
+
+Config example:
+
+```json
+"Stores": {
+  "Meta": {
+    "mysql/prod4": [
+      "mysql/prod4-lag",
+      "mysql/prod4-writer"
+    ]
+  },
+  "MySQL": {
+    "Clusters": {
+      "prod4-lag": {
+        ...
+      },
+      "prod4-writer": {
+        ...
+      }
+    }
+  }
+}
+```
+
+A call to `api/check/myapp/mysql/prod4` will invoke both `api/check/myapp/mysql/prod4-lag` and `api/check/myapp/mysql/prod4-writer` and return the _worst_ response.
+
+The name of the meta check is flexible. The below is perfectly valid:
+
+```json
+"Meta": {
+  "foo/bar": [
+    "mysql/prod4-lag",
+    "mysql/prod4-writer"
+  ],
+  "backend/database": [
+    "mysql/prod1-lag",
+    "mysql/prod2-lag",
+    "mysql/prod3-lag"
+  ]
+},
+```
+
+You will need to ensure the listed checks do indeed exist in the config file. You may have multiple levels of meta-checks but behavior is unexpected if you create an infinite loop.

--- a/go/base/metric.go
+++ b/go/base/metric.go
@@ -1,0 +1,20 @@
+package base
+
+import (
+	"fmt"
+	"strings"
+)
+
+func GetMetricName(storeType string, storeName string) (metricName string) {
+	return strings.Join([]string{storeType, storeName}, "/")
+}
+
+func ParseMetricName(metricName string) (storeType string, storeName string, err error) {
+	metricTokens := strings.Split(metricName, "/")
+	if len(metricTokens) != 2 {
+		return storeType, storeName, fmt.Errorf("Error parsing storename: %s", storeName)
+	}
+	storeType = metricTokens[0]
+	storeName = metricTokens[1]
+	return storeType, storeName, nil
+}

--- a/go/base/metric_test.go
+++ b/go/base/metric_test.go
@@ -1,0 +1,39 @@
+/*
+   Copyright 2017 GitHub Inc.
+	 See https://github.com/github/freno/blob/master/LICENSE
+*/
+
+package base
+
+import (
+	"testing"
+
+	"github.com/outbrain/golib/log"
+	test "github.com/outbrain/golib/tests"
+)
+
+func init() {
+	log.SetLevel(log.ERROR)
+}
+
+func TestGetMetricName(t *testing.T) {
+	result := GetMetricName("mysql", "mycluster")
+	test.S(t).ExpectEquals(result, "mysql/mycluster")
+}
+
+func TestParseMetricName(t *testing.T) {
+	{
+		storeType, storeName, err := ParseMetricName("mysql/mycluster")
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(storeType, "mysql")
+		test.S(t).ExpectEquals(storeName, "mycluster")
+	}
+	{
+		_, _, err := ParseMetricName("mysql")
+		test.S(t).ExpectNotNil(err)
+	}
+	{
+		_, _, err := ParseMetricName("freno/mysql/mycluster")
+		test.S(t).ExpectNotNil(err)
+	}
+}

--- a/go/config/meta_config.go
+++ b/go/config/meta_config.go
@@ -1,0 +1,10 @@
+package config
+
+//
+// Meta-checks configuration
+// A meta check aggregates one or more other checks, and will return the worst.
+//
+
+type MetaChecksListing []string
+
+type MetaChecks map[string]MetaChecksListing

--- a/go/config/store_config.go
+++ b/go/config/store_config.go
@@ -5,6 +5,7 @@ package config
 //
 
 type StoresSettings struct {
+	Meta  MetaChecks                 // All "meta" checks go here
 	MySQL MySQLConfigurationSettings // Any and all MySQL setups go here
 
 	// Futuristic stores can come here.

--- a/go/throttle/check_test.go
+++ b/go/throttle/check_test.go
@@ -1,0 +1,71 @@
+/*
+   Copyright 2017 GitHub Inc.
+	 See https://github.com/github/freno/blob/master/LICENSE
+*/
+
+package throttle
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/outbrain/golib/log"
+	test "github.com/outbrain/golib/tests"
+)
+
+func init() {
+	log.SetLevel(log.ERROR)
+}
+
+func TestAggregateCheckResults(t *testing.T) {
+	throttlerCheck := NewThrottlerCheck(nil)
+	{
+		checkResults := [](*CheckResult){
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+		}
+		result := throttlerCheck.aggregateCheckResults(checkResults)
+		test.S(t).ExpectEquals(result.StatusCode, http.StatusOK)
+	}
+	{
+		checkResults := [](*CheckResult){
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+			NewCheckResult(http.StatusNotFound, 0, 0, nil),
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+		}
+		result := throttlerCheck.aggregateCheckResults(checkResults)
+		test.S(t).ExpectEquals(result.StatusCode, http.StatusNotFound)
+	}
+	{
+		checkResults := [](*CheckResult){
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+			NewCheckResult(http.StatusTooManyRequests, 0, 0, nil),
+			NewCheckResult(http.StatusNotFound, 0, 0, nil),
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+		}
+		result := throttlerCheck.aggregateCheckResults(checkResults)
+		test.S(t).ExpectEquals(result.StatusCode, http.StatusTooManyRequests)
+	}
+	{
+		checkResults := [](*CheckResult){
+			NewCheckResult(http.StatusNotFound, 0, 0, nil),
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+			NewCheckResult(http.StatusTooManyRequests, 0, 0, nil),
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+		}
+		result := throttlerCheck.aggregateCheckResults(checkResults)
+		test.S(t).ExpectEquals(result.StatusCode, http.StatusTooManyRequests)
+	}
+	{
+		checkResults := [](*CheckResult){
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+			NewCheckResult(http.StatusTooManyRequests, 0, 0, nil),
+			NewCheckResult(http.StatusInternalServerError, 0, 0, nil),
+			NewCheckResult(http.StatusNotFound, 0, 0, nil),
+			NewCheckResult(http.StatusOK, 0, 0, nil),
+		}
+		result := throttlerCheck.aggregateCheckResults(checkResults)
+		test.S(t).ExpectEquals(result.StatusCode, http.StatusTooManyRequests)
+	}
+}

--- a/resources/freno.conf.sample.json
+++ b/resources/freno.conf.sample.json
@@ -6,18 +6,34 @@
   "RaftNodes": ["10.0.0.1", "10.0.0.2", "10.0.0.3"],
   "MemcacheServers": [],
   "Stores": {
+    "Meta": {
+      "mysql/prod4": [
+        "mysql/prod4-lag",
+        "mysql/prod4-writer"
+      ]
+    },
     "MySQL": {
       "User": "${mysql_user_env_variable}",
       "Password": "${mysql_password_env_variable}",
       "MetricQuery": "select unix_timestamp(now(6)) - unix_timestamp(ts) as lag_check from meta.heartbeat order by ts desc limit 1",
       "ThrottleThreshold": 1.0,
       "Clusters": {
-        "prod4": {
+        "prod4-lag": {
           "ThrottleThreshold": 0.8,
           "HAProxySettings": {
             "Host": "my.haproxy.mydomain.com",
             "Port": 1001,
             "PoolName": "my_prod4_pool"
+          }
+        },
+        "prod4-writer": {
+          "MetricQuery": "SELECT count FROM information_schema.innodb_metrics WHERE name = 'trx_rseg_history_len'",
+          "CacheMillis": 1000,
+          "ThrottleThreshold": 100000,
+          "StaticHostsSettings" : {
+              "Hosts": [
+                "my.master8.vip.com:3306"
+              ]
           }
         },
         "local": {

--- a/resources/freno.conf.skeleton.json
+++ b/resources/freno.conf.skeleton.json
@@ -6,6 +6,8 @@
   "RaftNodes": ["<ip.1>", "<ip.2>", "<ip.3>"],
   "MemcacheServers": [],
   "Stores": {
+    "Meta": {
+    },
     "MySQL": {
       "ThrottleThreshold": 1.0,
       "Clusters": {


### PR DESCRIPTION
This PR introduces meta-checks. From the outside a meta check looks just like any other check. But under the cover a meta check is an aggregation of multiple other checks.

For example, the check `api/check/theapp/mysql/cluster1-full` can aggregate multiple checks such as `api/check/theapp/mysql/cluster1-lag` and `api/check/theapp/mysql/cluster1-writeload`.

Checks can have any name. The above check doesn't have to be named `mysql`. It can also be named `api/check/theapp/foo/bar`.

Example configuration:

```json
  "Stores": {
    "Meta": {
        "mysql/cluster1-full": [
            "mysql/cluster1-lag",
            "mysql/cluster1-writeload"
        ]
    },
    "MySQL": {
        ...
    }
```

cc @github/database-infrastructure @miguelff 