### PR TITLE
Change of vtgate tablets API endpoint

### DIFF
--- a/go/vitess/api_client.go
+++ b/go/vitess/api_client.go
@@ -24,7 +24,7 @@ func constructAPIURL(api string, keyspace string, shard string) (url string) {
 	if !strings.HasSuffix(api, "/api") {
 		api = fmt.Sprintf("%s/api", api)
 	}
-	url = fmt.Sprintf("%s/ks_tablets/%s/%s", api, keyspace, shard)
+	url = fmt.Sprintf("%s/keyspace/%s/tablets/%s", api, keyspace, shard)
 
 	return url
 }


### PR DESCRIPTION
As per https://github.com/vitessio/vitess/pull/4232, API endpoint for getting a keyspace's tablets has hanged, and is now:

- `api/keyspace/<keyspace name>/tablets`, or
- `api/keyspace/<keyspace name>/tablets/<shard-name>`
