### PR TITLE
More frequent self-checks

### DIFF
--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -12,7 +12,7 @@ import (
 )
 
 const frenoAppName = "freno"
-const selfCheckInterval = 1 * time.Second
+const selfCheckInterval = 250 * time.Millisecond
 
 // ThrottlerCheck provides methdos for an app checking on metrics
 type ThrottlerCheck struct {

--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -12,7 +12,7 @@ import (
 )
 
 const frenoAppName = "freno"
-const selfCheckInterval = 250 * time.Millisecond
+const selfCheckInterval = 100 * time.Millisecond
 
 // ThrottlerCheck provides methdos for an app checking on metrics
 type ThrottlerCheck struct {


### PR DESCRIPTION
Followup to https://github.com/github/freno/pull/61, this increases self-check frequency to 10 times as second.

We find that on a competitive environment where other processes are aggressively polling and writing, `freno` may be unfortunate in never winning a check, even as an opportunity might be a few milliseconds away.

cc @github/database-infrastructure 