### PR TITLE
Support for IgnoreHosts config

### DIFF
--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -40,6 +40,10 @@ You will find the top-level configuration:
   "IgnoreHostsCount": 0,
   "HttpCheckPort": -1,
   "HttpCheckPath": "path-to-check",
+  "IgnoreHosts": [
+    "us-east-1",
+    "us-east-2"
+  ],
   "Clusters": {
   }
 }
@@ -66,6 +70,8 @@ These params apply in general to all MySQL clusters, unless specified differentl
 - `HttpCheckPath`: path to test. e.g. when `"HttpCheckPort": 1234` and `"HttpCheckPath": "health"`, `freno` will test `http://<mysql-box>:1234/health`.
 
   You may override `HttpCheckPath` on specific clusters.
+- `IgnoreHosts`: array of substrings. A host is completely ignored by `freno` if it contains a substring listed in `IgnoreHosts`.
+  Like other values, this value can be overridden per-cluster. A non-empty `IgnoreHosts` in a specific cluster will replace the `MySQL` scope definition, for that cluster. An empty `IgnoreHosts` in a cluster scope will not un-ignore the patterns specified in `MySQL` scope. If you want to un-ignore the `MySQL` scope use some thing like `"IgnoreHosts": ["--no-such-pattern--"],`, known to never match any of your hosts.
 
 Looking at clusters configuration:
 
@@ -80,6 +86,9 @@ Looking at clusters configuration:
     }
   },
   "sharded": {
+    "IgnoreHosts": [
+      "us-east-2"
+    ],
     "VitessSettings": {
       "API": "https://vtctld.example.com/api/",
       "Keyspace": "my_sharded_ks"

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -11,15 +11,16 @@ import (
 const DefaultMySQLPort = 3306
 
 type MySQLClusterConfigurationSettings struct {
-	User              string  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	Password          string  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	MetricQuery       string  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	CacheMillis       int     // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	ThrottleThreshold float64 // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	Port              int     // Specify if different than 3306 or if different than specified by MySQLConfigurationSettings
-	IgnoreHostsCount  int     // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
-	HttpCheckPort     int     // Specify if different than specified by MySQLConfigurationSettings. -1 to disable HTTP check
-	HttpCheckPath     string  //  Specify if different than specified by MySQLConfigurationSettings
+	User              string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	Password          string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	MetricQuery       string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	CacheMillis       int      // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	ThrottleThreshold float64  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	Port              int      // Specify if different than 3306 or if different than specified by MySQLConfigurationSettings
+	IgnoreHostsCount  int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	HttpCheckPort     int      // Specify if different than specified by MySQLConfigurationSettings. -1 to disable HTTP check
+	HttpCheckPath     string   // Specify if different than specified by MySQLConfigurationSettings
+	IgnoreHosts       []string // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 
 	HAProxySettings     HAProxyConfigurationSettings // If list of servers is to be acquired via HAProxy, provide this field
 	VitessSettings      VitessConfigurationSettings  // If list of servers is to be acquired via Vitess, provide this field
@@ -46,10 +47,11 @@ type MySQLConfigurationSettings struct {
 	MetricQuery       string
 	CacheMillis       int // optional, if defined then probe result will be cached, and future probes may use cached value
 	ThrottleThreshold float64
-	Port              int    // Specify if different than 3306; applies to all clusters
-	IgnoreHostsCount  int    // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
-	HttpCheckPort     int    // port for HTTP check. -1 to disable.
-	HttpCheckPath     string // If non-empty, requires HttpCheckPort
+	Port              int      // Specify if different than 3306; applies to all clusters
+	IgnoreHostsCount  int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	HttpCheckPort     int      // port for HTTP check. -1 to disable.
+	HttpCheckPath     string   // If non-empty, requires HttpCheckPort
+	IgnoreHosts       []string // If non empty, substrings to indicate hosts to be ignored/skipped
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }
@@ -99,6 +101,9 @@ func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
 		}
 		if clusterSettings.HttpCheckPath == "" {
 			clusterSettings.HttpCheckPath = settings.HttpCheckPath
+		}
+		if len(clusterSettings.IgnoreHosts) == 0 {
+			clusterSettings.IgnoreHosts = settings.IgnoreHosts
 		}
 	}
 	return nil

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -222,6 +222,12 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 	log.Debugf("refreshing MySQL inventory")
 
 	addInstanceKey := func(key *mysql.InstanceKey, clusterSettings *config.MySQLClusterConfigurationSettings, probes *mysql.Probes) {
+		for _, ignore := range clusterSettings.IgnoreHosts {
+			if strings.Contains(key.DisplayString(), ignore) {
+				log.Debugf("instance key ignored: %+v", key)
+				return
+			}
+		}
 		log.Debugf("read instance key: %+v", key)
 
 		probe := &mysql.Probe{


### PR DESCRIPTION
A new config, `IgnoreHosts` is introduced. Example:

```json
    "MySQL": {
      "ThrottleThreshold": 1,
      "IgnoreHosts": [
        "127.0.0.5"
      ],
       "Clusters": {
        "local": {
          "User": "msandbox",
          "Password": "msandbox",
          "CacheMillis": 5000,
          "ThrottleThreshold": 800,
          "IgnoreHosts": [
            "127.0.0.2"
          ],
          "StaticHostsSettings" : {
              "Hosts": [
                "127.0.0.2:5555",
                "127.0.0.1:20192",
                "127.0.0.1:20193",
                "127.0.0.1:20194"
              ]
          }
        }
      }
```
As shown in the above, `IgnoreHosts` can appear in `MySQL` scope, or can appear (and override) in per-cluster scope, similarly to other metrics.

`IgnoreHosts` is an array of strings; a `freno` ignores a host if the hostname has a substring found in `IgnoreHosts`. e.g., in the above `"0.0.2:"` would disable the host `"127.0.0.2:5555"`