### PR TITLE
Support IgnoreDialTcpErros config

### DIFF
--- a/go/base/throttle_metric.go
+++ b/go/base/throttle_metric.go
@@ -7,6 +7,7 @@ package base
 
 import (
 	"errors"
+	"strings"
 )
 
 type MetricResult interface {
@@ -19,6 +20,13 @@ var ThresholdExceededError = errors.New("Threshold exceeded")
 var noHostsError = errors.New("No hosts found")
 var noResultYetError = errors.New("Metric not collected yet")
 var NoSuchMetricError = errors.New("No such metric")
+
+func IsDialTcpError(e error) bool {
+	if e == nil {
+		return false
+	}
+	return strings.HasPrefix(e.Error(), "dial tcp")
+}
 
 type noHostsMetricResult struct{}
 

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -41,15 +41,16 @@ func (settings *MySQLClusterConfigurationSettings) postReadAdjustments() error {
 }
 
 type MySQLConfigurationSettings struct {
-	User              string
-	Password          string
-	MetricQuery       string
-	CacheMillis       int // optional, if defined then probe result will be cached, and future probes may use cached value
-	ThrottleThreshold float64
-	Port              int    // Specify if different than 3306; applies to all clusters
-	IgnoreHostsCount  int    // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
-	HttpCheckPort     int    // port for HTTP check. -1 to disable.
-	HttpCheckPath     string // If non-empty, requires HttpCheckPort
+	User               string
+	Password           string
+	MetricQuery        string
+	CacheMillis        int // optional, if defined then probe result will be cached, and future probes may use cached value
+	ThrottleThreshold  float64
+	Port               int    // Specify if different than 3306; applies to all clusters
+	IgnoreDialTcpErros bool   // Skip hosts where a metric cannot be retrieved due to TCP dial errors
+	IgnoreHostsCount   int    // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	HttpCheckPort      int    // port for HTTP check. -1 to disable.
+	HttpCheckPath      string // If non-empty, requires HttpCheckPort
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -42,17 +42,17 @@ func (settings *MySQLClusterConfigurationSettings) postReadAdjustments() error {
 }
 
 type MySQLConfigurationSettings struct {
-	User              string
-	Password          string
-	MetricQuery       string
-	CacheMillis       int // optional, if defined then probe result will be cached, and future probes may use cached value
-	ThrottleThreshold float64
-	Port              int      // Specify if different than 3306; applies to all clusters
-	IgnoreDialTcpErros bool   // Skip hosts where a metric cannot be retrieved due to TCP dial errors
-	IgnoreHostsCount  int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
-	HttpCheckPort     int      // port for HTTP check. -1 to disable.
-	HttpCheckPath     string   // If non-empty, requires HttpCheckPort
-	IgnoreHosts       []string // If non empty, substrings to indicate hosts to be ignored/skipped
+	User               string
+	Password           string
+	MetricQuery        string
+	CacheMillis        int // optional, if defined then probe result will be cached, and future probes may use cached value
+	ThrottleThreshold  float64
+	Port               int      // Specify if different than 3306; applies to all clusters
+	IgnoreDialTcpErros bool     // Skip hosts where a metric cannot be retrieved due to TCP dial errors
+	IgnoreHostsCount   int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	HttpCheckPort      int      // port for HTTP check. -1 to disable.
+	HttpCheckPath      string   // If non-empty, requires HttpCheckPort
+	IgnoreHosts        []string // If non empty, substrings to indicate hosts to be ignored/skipped
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -49,7 +49,7 @@ type MySQLConfigurationSettings struct {
 	CacheMillis          int // optional, if defined then probe result will be cached, and future probes may use cached value
 	ThrottleThreshold    float64
 	Port                 int      // Specify if different than 3306; applies to all clusters
-	IgnoreDialTcpErros bool     // Skip hosts where a metric cannot be retrieved due to TCP dial errors
+	IgnoreDialTcpErros   bool     // Skip hosts where a metric cannot be retrieved due to TCP dial errors
 	IgnoreHostsCount     int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
 	IgnoreHostsThreshold float64  // Threshold beyond which IgnoreHostsCount applies (default: 0)
 	HttpCheckPort        int      // port for HTTP check. -1 to disable.

--- a/go/throttle/mysql_test.go
+++ b/go/throttle/mysql_test.go
@@ -49,37 +49,37 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.1)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 3)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 3, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.6)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 4)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 4, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 5)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 5, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
@@ -107,19 +107,19 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
@@ -127,19 +127,19 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 
 	instanceResultsMap[key1] = base.NoSuchMetric
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1, false)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
@@ -167,13 +167,13 @@ func TestAggregateMySQLProbesWithHttpChecks(t *testing.T) {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 	}
 	{
 		clusterInstanceHttpCheckResultMap[mysql.MySQLHttpCheckHashKey(clusterName, &key2)] = http.StatusNotFound
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
@@ -182,7 +182,7 @@ func TestAggregateMySQLProbesWithHttpChecks(t *testing.T) {
 		for hashKey := range clusterInstanceHttpCheckResultMap {
 			clusterInstanceHttpCheckResultMap[hashKey] = http.StatusNotFound
 		}
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 	}

--- a/go/throttle/mysql_test.go
+++ b/go/throttle/mysql_test.go
@@ -107,37 +107,37 @@ func TestAggregateMySQLProbesNoErrorsIgnoreHostsThreshold(t *testing.T) {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, 1.0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false, 1.0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1, 1.0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1, false, 1.0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2, 1.0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2, false, 1.0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.1)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 3, 1.0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 3, false, 1.0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.6)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 4, 1.0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 4, false, 1.0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.6)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 5, 1.0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 5, false, 1.0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.6)

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -327,7 +327,7 @@ func (throttler *Throttler) aggregateMySQLMetrics() error {
 	for clusterName, probes := range throttler.mysqlInventory.ClustersProbes {
 		metricName := fmt.Sprintf("mysql/%s", clusterName)
 		ignoreHostsCount := throttler.mysqlInventory.IgnoreHostsCount[clusterName]
-		aggregatedMetric := aggregateMySQLProbes(probes, clusterName, throttler.mysqlInventory.InstanceKeyMetrics, throttler.mysqlInventory.ClusterInstanceHttpChecks, ignoreHostsCount)
+		aggregatedMetric := aggregateMySQLProbes(probes, clusterName, throttler.mysqlInventory.InstanceKeyMetrics, throttler.mysqlInventory.ClusterInstanceHttpChecks, ignoreHostsCount, config.Settings().Stores.MySQL.IgnoreDialTcpErros)
 		go throttler.aggregatedMetrics.Set(metricName, aggregatedMetric, cache.DefaultExpiration)
 		if throttler.memcacheClient != nil {
 			go func() {


### PR DESCRIPTION
When this new `MySQL`-scope config `"IgnoreDialTcpErros": true`, `freno` will silently ignore (skip) hosts which is failed to connect via TCP dial error.

The idea is that `freno` would only consider hosts which it is able to reach.

As with other skips/ignores, if `freno` exhausts the entire roster and is left with no actual hosts that it can probe, it returns an error. So, for example, a `api/check/me/mysql/mysqlcluster1` will skip all hosts that are DOWN, and return the max lag of the remaining hosts. If all hosts are down, that's an error.

cc @github/database-infrastructure 