### PR TITLE
IgnoreDownTaggedHosts: ignore hosts that are marked as 'DOWN' in HAProxy

### DIFF
--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -105,7 +105,7 @@ This introduces two clusters: `prod4` and `local`. `freno` will only serve reque
 Noteworthy:
 
 - `prod4` chooses to (but doesn't have to) override the `ThrottleThreshold` to `0.8` seconds
-- `prod4` list of servers is dictated by `HAProxy`. `freno` will routinely and dynamically poll given HAProxy server for list of hosts. These will include any hosts not in `NOLB`.
+- `prod4` list of servers is dictated by `HAProxy`. `freno` will routinely and dynamically poll given HAProxy server for list of hosts. These will include hosts that are `UP`, exclude hosts that are `NOLB`, and conditionally include `DOWN` hosts based on `IgnoreDownTaggedHosts` config.
 - `local` cluster chooses to override `User`, `Password` and `IgnoreHostsCount`.
 - `local` cluster defines a static list of hosts.
 

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -41,15 +41,16 @@ func (settings *MySQLClusterConfigurationSettings) postReadAdjustments() error {
 }
 
 type MySQLConfigurationSettings struct {
-	User              string
-	Password          string
-	MetricQuery       string
-	CacheMillis       int // optional, if defined then probe result will be cached, and future probes may use cached value
-	ThrottleThreshold float64
-	Port              int    // Specify if different than 3306; applies to all clusters
-	IgnoreHostsCount  int    // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
-	HttpCheckPort     int    // port for HTTP check. -1 to disable.
-	HttpCheckPath     string // If non-empty, requires HttpCheckPort
+	User                  string
+	Password              string
+	MetricQuery           string
+	CacheMillis           int // optional, if defined then probe result will be cached, and future probes may use cached value
+	ThrottleThreshold     float64
+	Port                  int    // Specify if different than 3306; applies to all clusters
+	IgnoreHostsCount      int    // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	HttpCheckPort         int    // port for HTTP check. -1 to disable.
+	HttpCheckPath         string // If non-empty, requires HttpCheckPort
+	IgnoreDownTaggedHosts bool   // Ignore hosts reported `DOWN` in HAProxy or other service
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }

--- a/go/haproxy/parser.go
+++ b/go/haproxy/parser.go
@@ -42,9 +42,12 @@ func parseLines(csv string) []string {
 }
 
 // ParseHosts reads HAProxy CSV lines and returns lists of hosts participating in the given pool (backend)
-// Returned are all non-disabled hosts in given backend. Thus, a NOLB is skipped; any UP or DOWN hosts are returned.
+// Returned are all non-disabled hosts in given backend. Thus:
+// - a NOLB is skipped
+// - UP is included
+// - DOWN is included based on argument conditional.
 // Such list indicates the hosts which can be expected to be active, which is then the list freno will probe.
-func ParseHosts(csvLines []string, poolName string) (hosts []string, err error) {
+func ParseHosts(csvLines []string, poolName string, skipDown bool) (hosts []string, err error) {
 	if len(csvLines) < 1 {
 		return hosts, HAProxyEmptyStatus
 	}
@@ -93,7 +96,9 @@ func ParseHosts(csvLines []string, poolName string) (hosts []string, err error) 
 					}
 				case "DOWN":
 					{
-						hosts = append(hosts, host)
+						if !skipDown {
+							hosts = append(hosts, host)
+						}
 					}
 				}
 				if fullStatus == "no check" {
@@ -116,9 +121,9 @@ func ParseHosts(csvLines []string, poolName string) (hosts []string, err error) 
 
 // ParseCsvHosts reads HAProxy CSV text and returns lists of hosts participating in the given pool (backend).
 // See comment for ParseHosts
-func ParseCsvHosts(csv string, poolName string) (hosts []string, err error) {
+func ParseCsvHosts(csv string, poolName string, skipDown bool) (hosts []string, err error) {
 	csvLines := parseLines(csv)
-	return ParseHosts(csvLines, poolName)
+	return ParseHosts(csvLines, poolName, skipDown)
 }
 
 // Read will read HAProxy URI and return with the CSV text

--- a/go/haproxy/parser_test.go
+++ b/go/haproxy/parser_test.go
@@ -93,34 +93,39 @@ func TestParseHeader(t *testing.T) {
 
 func TestParseHosts(t *testing.T) {
 	{
-		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_rw_main")
+		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_rw_main", false)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0c-dc"}))
 	}
 	{
-		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_main")
+		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_main", false)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0a-dc", "mysqlcluster0b-dc"}))
 	}
 	{
-		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_backup")
+		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_backup", false)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0e-dc", "mysqlcluster0f-dc", "mysqlcluster0h-dc"}))
+	}
+	{
+		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_backup", true)
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0h-dc"}))
 	}
 }
 
 func TestParseHostsTransitioning(t *testing.T) {
 	{
-		hosts, err := ParseCsvHosts(csvTransitioning, "mysqlcluster0_ro_main")
+		hosts, err := ParseCsvHosts(csvTransitioning, "mysqlcluster0_ro_main", false)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0b-dc"}))
 	}
 	{
-		_, err := ParseCsvHosts(csvTransitioningAllUp, "mysqlcluster0_ro_main")
+		_, err := ParseCsvHosts(csvTransitioningAllUp, "mysqlcluster0_ro_main", false)
 		test.S(t).ExpectEquals(err, HAProxyAllUpHostsTransitioning)
 	}
 	{
-		_, err := ParseCsvHosts(csvTransitioningAll, "mysqlcluster0_ro_main")
+		_, err := ParseCsvHosts(csvTransitioningAll, "mysqlcluster0_ro_main", false)
 		test.S(t).ExpectEquals(err, HAProxyAllHostsTransitioning)
 	}
 }

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -180,14 +180,22 @@ func (api *APIImpl) ReadCheck(w http.ResponseWriter, r *http.Request, ps httprou
 
 // AggregatedMetrics returns a snapshot of all current aggregated metrics
 func (api *APIImpl) AggregatedMetrics(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	brief := (r.URL.Query().Get("brief") == "true")
+
 	w.Header().Set("Content-Type", "application/json")
 	aggregatedMetrics := api.throttlerCheck.AggregatedMetrics()
 	responseMap := map[string]string{}
 	for metricName, metric := range aggregatedMetrics {
 		value, err := metric.Get()
-		description := fmt.Sprintf("%+v", value)
-		if err != nil {
-			description = fmt.Sprintf("%+v, %+s", description, err.Error())
+		description := ""
+		if err == nil {
+			if brief {
+				description = fmt.Sprintf("%.3f", value)
+			} else {
+				description = fmt.Sprintf("%f", value)
+			}
+		} else {
+			description = fmt.Sprintf("error: %s", err.Error())
 		}
 		responseMap[metricName] = description
 	}

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -236,7 +236,8 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 		(*probes)[*key] = probe
 	}
 
-	for clusterName, clusterSettings := range config.Settings().Stores.MySQL.Clusters {
+	mysqlConfig := &config.Settings().Stores.MySQL
+	for clusterName, clusterSettings := range mysqlConfig.Clusters {
 		clusterName := clusterName
 		clusterSettings := clusterSettings
 		// config may dynamically change, but internal structure (config.Settings().Stores.MySQL.Clusters in our case)
@@ -250,7 +251,7 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 					return log.Errorf("Unable to get HAproxy data from %s:%d: %+v", clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, err)
 				}
 				poolName := clusterSettings.HAProxySettings.PoolName
-				hosts, err := haproxy.ParseCsvHosts(csv, poolName)
+				hosts, err := haproxy.ParseCsvHosts(csv, poolName, mysqlConfig.IgnoreDownTaggedHosts)
 				if err != nil {
 					return log.Errorf("Unable to get HAproxy hosts from %s:%d/#%s: %+v", clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, poolName, err)
 				}


### PR DESCRIPTION
# Do not merge

A new config variable `IgnoreDownTaggedHosts` can instruct `freno` to ignore hosts marked as `DOWN` in `HAProxy`. By default `freno` includes `UP`, `DOWN` hosts and excludes `NOLB` hosts parsed from HAProxy.

cc @github/database-infrastructure 