### PR TITLE
Introducing `IgnoreHostsThreshold` config variable

### DIFF
--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -38,6 +38,7 @@ You will find the top-level configuration:
   "CacheMillis": 0,
   "ThrottleThreshold": 1.0,
   "IgnoreHostsCount": 0,
+  "IgnoreHostsThreshold": 0.0,
   "HttpCheckPort": -1,
   "HttpCheckPath": "path-to-check",
   "IgnoreHosts": [
@@ -63,6 +64,8 @@ These params apply in general to all MySQL clusters, unless specified differentl
   - Note: valid range is `[0..)` (`0` or more), where lower values are stricter and higher values are more permissive.
   - Note: use _seconds_ as replication lag time unit. In the above we throttle above `1.0` seconds.
 - `IgnoreHostsCount`: number of hosts that can be ignored while aggregating cluster's values. For example, if `IgnoreHostsCount` is `2`, then up to `2` hosts that have errors are silently ignored. Or, if there's no errors, the two highest values will be ignored (so if these two values exceed the cluster's threshold, `freno` may still be happy to allow writes to the cluster).
+- `IgnoreHostsThreshold`: applies a conditional to the `IgnoreHostsCount` logic: for hosts with errors, no conditional applies. For hosts reporting a value, the value needs to be _higher_ than given threshold to be ignored.
+  A use case: ignore up to `n` lagging replicas, on condition that they're lagging _at least_ `10.0sec`.
 - `HttpCheckPort`: when `> 0`, and together with `HttpCheckPath`, `freno` will run a HTTP check on the MySQL boxes. For a given cluster there can only be one HTTP check on a MySQL box, even if one has multiple MySQL services running on that box.
   The HTTP check may return any HTTP status. The `404 Not Found` status is special: `freno` will completely disregard hosts where HTTP checks return `404`.
 

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -11,16 +11,17 @@ import (
 const DefaultMySQLPort = 3306
 
 type MySQLClusterConfigurationSettings struct {
-	User              string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	Password          string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	MetricQuery       string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	CacheMillis       int      // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	ThrottleThreshold float64  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
-	Port              int      // Specify if different than 3306 or if different than specified by MySQLConfigurationSettings
-	IgnoreHostsCount  int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
-	HttpCheckPort     int      // Specify if different than specified by MySQLConfigurationSettings. -1 to disable HTTP check
-	HttpCheckPath     string   // Specify if different than specified by MySQLConfigurationSettings
-	IgnoreHosts       []string // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	User                 string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	Password             string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	MetricQuery          string   // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	CacheMillis          int      // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	ThrottleThreshold    float64  // override MySQLConfigurationSettings's, or leave empty to inherit those settings
+	Port                 int      // Specify if different than 3306 or if different than specified by MySQLConfigurationSettings
+	IgnoreHostsCount     int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	IgnoreHostsThreshold float64  // Threshold beyond which IgnoreHostsCount applies (default: 0)
+	HttpCheckPort        int      // Specify if different than specified by MySQLConfigurationSettings. -1 to disable HTTP check
+	HttpCheckPath        string   // Specify if different than specified by MySQLConfigurationSettings
+	IgnoreHosts          []string // override MySQLConfigurationSettings's, or leave empty to inherit those settings
 
 	HAProxySettings     HAProxyConfigurationSettings // If list of servers is to be acquired via HAProxy, provide this field
 	VitessSettings      VitessConfigurationSettings  // If list of servers is to be acquired via Vitess, provide this field
@@ -42,16 +43,17 @@ func (settings *MySQLClusterConfigurationSettings) postReadAdjustments() error {
 }
 
 type MySQLConfigurationSettings struct {
-	User              string
-	Password          string
-	MetricQuery       string
-	CacheMillis       int // optional, if defined then probe result will be cached, and future probes may use cached value
-	ThrottleThreshold float64
-	Port              int      // Specify if different than 3306; applies to all clusters
-	IgnoreHostsCount  int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
-	HttpCheckPort     int      // port for HTTP check. -1 to disable.
-	HttpCheckPath     string   // If non-empty, requires HttpCheckPort
-	IgnoreHosts       []string // If non empty, substrings to indicate hosts to be ignored/skipped
+	User                 string
+	Password             string
+	MetricQuery          string
+	CacheMillis          int // optional, if defined then probe result will be cached, and future probes may use cached value
+	ThrottleThreshold    float64
+	Port                 int      // Specify if different than 3306; applies to all clusters
+	IgnoreHostsCount     int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
+	IgnoreHostsThreshold float64  // Threshold beyond which IgnoreHostsCount applies (default: 0)
+	HttpCheckPort        int      // port for HTTP check. -1 to disable.
+	HttpCheckPath        string   // If non-empty, requires HttpCheckPort
+	IgnoreHosts          []string // If non empty, substrings to indicate hosts to be ignored/skipped
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }
@@ -95,6 +97,9 @@ func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
 		}
 		if clusterSettings.IgnoreHostsCount == 0 {
 			clusterSettings.IgnoreHostsCount = settings.IgnoreHostsCount
+		}
+		if clusterSettings.IgnoreHostsThreshold == 0 {
+			clusterSettings.IgnoreHostsThreshold = settings.IgnoreHostsThreshold
 		}
 		if clusterSettings.HttpCheckPort == 0 {
 			clusterSettings.HttpCheckPort = settings.HttpCheckPort

--- a/go/mysql/mysql_inventory.go
+++ b/go/mysql/mysql_inventory.go
@@ -15,6 +15,7 @@ type ClusterInstanceHttpCheckResultMap map[string]int
 type MySQLInventory struct {
 	ClustersProbes            map[string](*Probes)
 	IgnoreHostsCount          map[string]int
+	IgnoreHostsThreshold      map[string]float64
 	InstanceKeyMetrics        InstanceMetricResultMap
 	ClusterInstanceHttpChecks ClusterInstanceHttpCheckResultMap
 }
@@ -23,6 +24,7 @@ func NewMySQLInventory() *MySQLInventory {
 	inventory := &MySQLInventory{
 		ClustersProbes:            make(map[string](*Probes)),
 		IgnoreHostsCount:          make(map[string]int),
+		IgnoreHostsThreshold:      make(map[string]float64),
 		InstanceKeyMetrics:        make(map[InstanceKey]base.MetricResult),
 		ClusterInstanceHttpChecks: make(map[string]int),
 	}

--- a/go/mysql/probe.go
+++ b/go/mysql/probe.go
@@ -30,9 +30,10 @@ type Probe struct {
 type Probes map[InstanceKey](*Probe)
 
 type ClusterProbes struct {
-	ClusterName      string
-	IgnoreHostsCount int
-	InstanceProbes   *Probes
+	ClusterName          string
+	IgnoreHostsCount     int
+	IgnoreHostsThreshold float64
+	InstanceProbes       *Probes
 }
 
 func NewProbes() *Probes {

--- a/go/throttle/mysql_test.go
+++ b/go/throttle/mysql_test.go
@@ -49,40 +49,98 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.1)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 3)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 3, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.6)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 4)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 4, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 5)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 5, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 0.3)
+	}
+}
+
+func TestAggregateMySQLProbesNoErrorsIgnoreHostsThreshold(t *testing.T) {
+	clusterName := "c0"
+	instanceResultsMap := mysql.InstanceMetricResultMap{
+		key1: base.NewSimpleMetricResult(1.2),
+		key2: base.NewSimpleMetricResult(1.7),
+		key3: base.NewSimpleMetricResult(0.3),
+		key4: base.NewSimpleMetricResult(0.6),
+		key5: base.NewSimpleMetricResult(1.1),
+	}
+	clusterInstanceHttpCheckResultMap := mysql.ClusterInstanceHttpCheckResultMap{
+		mysql.MySQLHttpCheckHashKey(clusterName, &key1): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key2): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key3): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key4): http.StatusOK,
+		mysql.MySQLHttpCheckHashKey(clusterName, &key5): http.StatusOK,
+	}
+	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
+	for key := range instanceResultsMap {
+		probes[key] = &mysql.Probe{Key: key}
+	}
+	{
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, 1.0)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 1.7)
+	}
+	{
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1, 1.0)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 1.2)
+	}
+	{
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2, 1.0)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 1.1)
+	}
+	{
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 3, 1.0)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 0.6)
+	}
+	{
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 4, 1.0)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 0.6)
+	}
+	{
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 5, 1.0)
+		value, err := worstMetric.Get()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(value, 0.6)
 	}
 }
 
@@ -107,19 +165,19 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
@@ -127,19 +185,19 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 
 	instanceResultsMap[key1] = base.NoSuchMetric
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 1, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 		test.S(t).ExpectEquals(err, base.NoSuchMetricError)
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 2, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.7)
@@ -167,13 +225,13 @@ func TestAggregateMySQLProbesWithHttpChecks(t *testing.T) {
 		probes[key] = &mysql.Probe{Key: key}
 	}
 	{
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 	}
 	{
 		clusterInstanceHttpCheckResultMap[mysql.MySQLHttpCheckHashKey(clusterName, &key2)] = http.StatusNotFound
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, 0)
 		value, err := worstMetric.Get()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(value, 1.2)
@@ -182,7 +240,7 @@ func TestAggregateMySQLProbesWithHttpChecks(t *testing.T) {
 		for hashKey := range clusterInstanceHttpCheckResultMap {
 			clusterInstanceHttpCheckResultMap[hashKey] = http.StatusNotFound
 		}
-		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0)
+		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, 0)
 		_, err := worstMetric.Get()
 		test.S(t).ExpectNotNil(err)
 	}


### PR DESCRIPTION
`IgnoreHostsThreshold`: applies a conditional to the `IgnoreHostsCount` logic: for hosts with errors, no conditional applies. For hosts reporting a value, the value needs to be _higher_ than given threshold to be ignored.

A use case: ignore up to `n` lagging replicas, on condition that they're lagging _at least_ `10.0sec`.
In this use case, we may expect that hosts lagging over `10.0sec` are auto-evicted from read-pool by a proxy.

cc @github/database-infrastructure 