### PR TITLE
Fixed IgnoreDialTcpErrors typo

### DIFF
--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -49,7 +49,7 @@ type MySQLConfigurationSettings struct {
 	CacheMillis          int // optional, if defined then probe result will be cached, and future probes may use cached value
 	ThrottleThreshold    float64
 	Port                 int      // Specify if different than 3306; applies to all clusters
-	IgnoreDialTcpErrors   bool     // Skip hosts where a metric cannot be retrieved due to TCP dial errors
+	IgnoreDialTcpErrors  bool     // Skip hosts where a metric cannot be retrieved due to TCP dial errors
 	IgnoreHostsCount     int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
 	IgnoreHostsThreshold float64  // Threshold beyond which IgnoreHostsCount applies (default: 0)
 	HttpCheckPort        int      // port for HTTP check. -1 to disable.

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -49,7 +49,7 @@ type MySQLConfigurationSettings struct {
 	CacheMillis          int // optional, if defined then probe result will be cached, and future probes may use cached value
 	ThrottleThreshold    float64
 	Port                 int      // Specify if different than 3306; applies to all clusters
-	IgnoreDialTcpErros   bool     // Skip hosts where a metric cannot be retrieved due to TCP dial errors
+	IgnoreDialTcpErrors   bool     // Skip hosts where a metric cannot be retrieved due to TCP dial errors
 	IgnoreHostsCount     int      // Number of hosts that can be skipped/ignored even on error or on exceeding theesholds
 	IgnoreHostsThreshold float64  // Threshold beyond which IgnoreHostsCount applies (default: 0)
 	HttpCheckPort        int      // port for HTTP check. -1 to disable.

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -336,7 +336,7 @@ func (throttler *Throttler) aggregateMySQLMetrics() error {
 		metricName := fmt.Sprintf("mysql/%s", clusterName)
 		ignoreHostsCount := throttler.mysqlInventory.IgnoreHostsCount[clusterName]
 		ignoreHostsThreshold := throttler.mysqlInventory.IgnoreHostsThreshold[clusterName]
-		aggregatedMetric := aggregateMySQLProbes(probes, clusterName, throttler.mysqlInventory.InstanceKeyMetrics, throttler.mysqlInventory.ClusterInstanceHttpChecks, ignoreHostsCount, config.Settings().Stores.MySQL.IgnoreDialTcpErros, ignoreHostsThreshold)
+		aggregatedMetric := aggregateMySQLProbes(probes, clusterName, throttler.mysqlInventory.InstanceKeyMetrics, throttler.mysqlInventory.ClusterInstanceHttpChecks, ignoreHostsCount, config.Settings().Stores.MySQL.IgnoreDialTcpErrors, ignoreHostsThreshold)
 		go throttler.aggregatedMetrics.Set(metricName, aggregatedMetric, cache.DefaultExpiration)
 		if throttler.memcacheClient != nil {
 			go func() {


### PR DESCRIPTION
As per https://github.com/github/freno/pull/78#discussion_r249034696, this PR fixes config typo from `IgnoreDialTcpErros` to `IgnoreDialTcpErrors`.

cc @mrluanma 