### PR TITLE
More complete parsing of HAProxy status

### DIFF
--- a/go/haproxy/host.go
+++ b/go/haproxy/host.go
@@ -1,0 +1,37 @@
+package haproxy
+
+import ()
+
+type BackendHostStatus string
+
+const (
+	StatusDown    BackendHostStatus = "DOWN"
+	StatusNOLB    BackendHostStatus = "NOLB"
+	StatusUp      BackendHostStatus = "UP"
+	StatusNoCheck BackendHostStatus = "no check"
+	StatusUnknown BackendHostStatus = "unkown"
+)
+
+func ToBackendHostStatus(status string) BackendHostStatus {
+	switch status {
+	case "DOWN":
+		return StatusDown
+	case "NOLB":
+		return StatusNOLB
+	case "UP":
+		return StatusUp
+	case "no check":
+		return StatusNoCheck
+	default:
+		return StatusUnknown
+	}
+}
+
+type BackendHost struct {
+	Hostname string
+	Status   BackendHostStatus
+}
+
+func NewBackendHost(hostname string, status BackendHostStatus) *BackendHost {
+	return &BackendHost{Hostname: hostname, Status: status}
+}

--- a/go/haproxy/host.go
+++ b/go/haproxy/host.go
@@ -1,7 +1,5 @@
 package haproxy
 
-import ()
-
 type BackendHostStatus string
 
 const (

--- a/go/haproxy/host.go
+++ b/go/haproxy/host.go
@@ -28,10 +28,11 @@ func ToBackendHostStatus(status string) BackendHostStatus {
 }
 
 type BackendHost struct {
-	Hostname string
-	Status   BackendHostStatus
+	Hostname        string
+	Status          BackendHostStatus
+	IsTransitioning bool
 }
 
-func NewBackendHost(hostname string, status BackendHostStatus) *BackendHost {
-	return &BackendHost{Hostname: hostname, Status: status}
+func NewBackendHost(hostname string, status BackendHostStatus, isTransitioning bool) *BackendHost {
+	return &BackendHost{Hostname: hostname, Status: status, IsTransitioning: isTransitioning}
 }

--- a/go/haproxy/parser_test.go
+++ b/go/haproxy/parser_test.go
@@ -93,34 +93,68 @@ func TestParseHeader(t *testing.T) {
 
 func TestParseHosts(t *testing.T) {
 	{
-		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_rw_main")
+		hosts, backendHosts, err := ParseCsvHosts(csv0, "mysqlcluster0_rw_main")
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0c-dc"}))
+		test.S(t).ExpectEquals(len(backendHosts), 4)
 	}
 	{
-		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_main")
+		hosts, backendHosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_main")
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0a-dc", "mysqlcluster0b-dc"}))
+		test.S(t).ExpectEquals(len(backendHosts), 4)
 	}
 	{
-		hosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_backup")
+		hosts, backendHosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_backup")
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0e-dc", "mysqlcluster0f-dc", "mysqlcluster0h-dc"}))
+		test.S(t).ExpectEquals(len(backendHosts), 4)
 	}
 }
 
 func TestParseHostsTransitioning(t *testing.T) {
 	{
-		hosts, err := ParseCsvHosts(csvTransitioning, "mysqlcluster0_ro_main")
+		hosts, backendHosts, err := ParseCsvHosts(csvTransitioning, "mysqlcluster0_ro_main")
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0b-dc"}))
+		test.S(t).ExpectEquals(len(backendHosts), 4)
 	}
 	{
-		_, err := ParseCsvHosts(csvTransitioningAllUp, "mysqlcluster0_ro_main")
+		_, backendHosts, err := ParseCsvHosts(csvTransitioningAllUp, "mysqlcluster0_ro_main")
 		test.S(t).ExpectEquals(err, HAProxyAllUpHostsTransitioning)
+		test.S(t).ExpectEquals(len(backendHosts), 4)
 	}
 	{
-		_, err := ParseCsvHosts(csvTransitioningAll, "mysqlcluster0_ro_main")
+		_, backendHosts, err := ParseCsvHosts(csvTransitioningAll, "mysqlcluster0_ro_main")
 		test.S(t).ExpectEquals(err, HAProxyAllHostsTransitioning)
+		test.S(t).ExpectEquals(len(backendHosts), 4)
+	}
+}
+
+func TestParseStatus(t *testing.T) {
+	{
+		status, isTransitioning := ParseStatus("NOLB")
+		test.S(t).ExpectFalse(isTransitioning)
+		test.S(t).ExpectEquals(status, StatusNOLB)
+	}
+	{
+		status, isTransitioning := ParseStatus("NOLB 1/2")
+		test.S(t).ExpectTrue(isTransitioning)
+		test.S(t).ExpectEquals(status, StatusNOLB)
+	}
+	{
+		status, isTransitioning := ParseStatus("UP 1/2")
+		test.S(t).ExpectTrue(isTransitioning)
+		test.S(t).ExpectEquals(status, StatusUp)
+	}
+	{
+		status, isTransitioning := ParseStatus("DOWN")
+		test.S(t).ExpectFalse(isTransitioning)
+		test.S(t).ExpectEquals(status, StatusDown)
+	}
+	{
+		status, isTransitioning := ParseStatus("no check")
+		test.S(t).ExpectFalse(isTransitioning)
+		test.S(t).ExpectEquals(status, StatusNoCheck)
 	}
 }

--- a/go/haproxy/parser_test.go
+++ b/go/haproxy/parser_test.go
@@ -93,39 +93,47 @@ func TestParseHeader(t *testing.T) {
 
 func TestParseHosts(t *testing.T) {
 	{
-		hosts, backendHosts, err := ParseCsvHosts(csv0, "mysqlcluster0_rw_main")
+		backendHosts, err := ParseCsvHosts(csv0, "mysqlcluster0_rw_main")
 		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(len(backendHosts), 4)
+
+		hosts := FilterThrotllerHosts(backendHosts)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0c-dc"}))
-		test.S(t).ExpectEquals(len(backendHosts), 4)
 	}
 	{
-		hosts, backendHosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_main")
+		backendHosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_main")
 		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(len(backendHosts), 4)
+
+		hosts := FilterThrotllerHosts(backendHosts)
 		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0a-dc", "mysqlcluster0b-dc"}))
-		test.S(t).ExpectEquals(len(backendHosts), 4)
 	}
 	{
-		hosts, backendHosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_backup")
+		backendHosts, err := ParseCsvHosts(csv0, "mysqlcluster0_ro_backup")
 		test.S(t).ExpectNil(err)
-		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0e-dc", "mysqlcluster0f-dc", "mysqlcluster0h-dc"}))
 		test.S(t).ExpectEquals(len(backendHosts), 4)
+
+		hosts := FilterThrotllerHosts(backendHosts)
+		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0e-dc", "mysqlcluster0f-dc", "mysqlcluster0h-dc"}))
 	}
 }
 
 func TestParseHostsTransitioning(t *testing.T) {
 	{
-		hosts, backendHosts, err := ParseCsvHosts(csvTransitioning, "mysqlcluster0_ro_main")
+		backendHosts, err := ParseCsvHosts(csvTransitioning, "mysqlcluster0_ro_main")
 		test.S(t).ExpectNil(err)
-		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0b-dc"}))
 		test.S(t).ExpectEquals(len(backendHosts), 4)
+
+		hosts := FilterThrotllerHosts(backendHosts)
+		test.S(t).ExpectTrue(reflect.DeepEqual(hosts, []string{"mysqlcluster0b-dc"}))
 	}
 	{
-		_, backendHosts, err := ParseCsvHosts(csvTransitioningAllUp, "mysqlcluster0_ro_main")
+		backendHosts, err := ParseCsvHosts(csvTransitioningAllUp, "mysqlcluster0_ro_main")
 		test.S(t).ExpectEquals(err, HAProxyAllUpHostsTransitioning)
 		test.S(t).ExpectEquals(len(backendHosts), 4)
 	}
 	{
-		_, backendHosts, err := ParseCsvHosts(csvTransitioningAll, "mysqlcluster0_ro_main")
+		backendHosts, err := ParseCsvHosts(csvTransitioningAll, "mysqlcluster0_ro_main")
 		test.S(t).ExpectEquals(err, HAProxyAllHostsTransitioning)
 		test.S(t).ExpectEquals(len(backendHosts), 4)
 	}

--- a/go/haproxy/throttle.go
+++ b/go/haproxy/throttle.go
@@ -1,0 +1,23 @@
+package haproxy
+
+import ()
+
+func FilterThrotllerHosts(backendHosts [](*BackendHost)) (hosts []string) {
+	for _, backendHost := range backendHosts {
+		hostIsRelevant := false
+		switch backendHost.Status {
+		case StatusUp:
+			if !backendHost.IsTransitioning {
+				hostIsRelevant = true
+			}
+		case StatusDown:
+			hostIsRelevant = true
+		case StatusNoCheck:
+			hostIsRelevant = true
+		}
+		if hostIsRelevant {
+			hosts = append(hosts, backendHost.Hostname)
+		}
+	}
+	return hosts
+}

--- a/go/haproxy/throttle.go
+++ b/go/haproxy/throttle.go
@@ -1,7 +1,5 @@
 package haproxy
 
-import ()
-
 func FilterThrotllerHosts(backendHosts [](*BackendHost)) (hosts []string) {
 	for _, backendHost := range backendHosts {
 		hostIsRelevant := false

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -256,17 +256,16 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 			if !clusterSettings.HAProxySettings.IsEmpty() {
 				poolName := clusterSettings.HAProxySettings.PoolName
 
-        totalHosts := []string{}
+				totalHosts := []string{}
 				for _, hostPort := range clusterSettings.HAProxySettings.GetProxyAddresses() {
 					log.Debugf("getting haproxy data from %s:%d", hostPort.Host, hostPort.Port)
 					csv, err := haproxy.Read(hostPort.Host, hostPort.Port)
 					if err != nil {
 						return log.Errorf("Unable to get HAproxy data from %s:%d: %+v", hostPort.Host, hostPort, err)
 					}
-          
-          
+
 					if backendHosts, err := haproxy.ParseCsvHosts(csv, poolName); err == nil {
-    				hosts := haproxy.FilterThrotllerHosts(backendHosts)
+						hosts := haproxy.FilterThrotllerHosts(backendHosts)
 						totalHosts = append(totalHosts, hosts...)
 						log.Debugf("Read %+v hosts from haproxy %s:%d/#%s", len(hosts), hostPort.Host, hostPort.Port, poolName)
 					} else {

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -256,7 +256,7 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 					return log.Errorf("Unable to get HAproxy data from %s:%d: %+v", clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, err)
 				}
 				poolName := clusterSettings.HAProxySettings.PoolName
-				hosts, err := haproxy.ParseCsvHosts(csv, poolName)
+				hosts, _, err := haproxy.ParseCsvHosts(csv, poolName)
 				if err != nil {
 					return log.Errorf("Unable to get HAproxy hosts from %s:%d/#%s: %+v", clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, poolName, err)
 				}

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -255,7 +255,6 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 			throttler.mysqlClusterThresholds.Set(clusterName, clusterSettings.ThrottleThreshold, cache.DefaultExpiration)
 			if !clusterSettings.HAProxySettings.IsEmpty() {
 				poolName := clusterSettings.HAProxySettings.PoolName
-
 				totalHosts := []string{}
 				for _, hostPort := range clusterSettings.HAProxySettings.GetProxyAddresses() {
 					log.Debugf("getting haproxy data from %s:%d", hostPort.Host, hostPort.Port)
@@ -263,7 +262,6 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 					if err != nil {
 						return log.Errorf("Unable to get HAproxy data from %s:%d: %+v", hostPort.Host, hostPort, err)
 					}
-
 					if backendHosts, err := haproxy.ParseCsvHosts(csv, poolName); err == nil {
 						hosts := haproxy.FilterThrotllerHosts(backendHosts)
 						totalHosts = append(totalHosts, hosts...)

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -256,10 +256,11 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 					return log.Errorf("Unable to get HAproxy data from %s:%d: %+v", clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, err)
 				}
 				poolName := clusterSettings.HAProxySettings.PoolName
-				hosts, _, err := haproxy.ParseCsvHosts(csv, poolName)
+				backendHosts, err := haproxy.ParseCsvHosts(csv, poolName)
 				if err != nil {
 					return log.Errorf("Unable to get HAproxy hosts from %s:%d/#%s: %+v", clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, poolName, err)
 				}
+				hosts := haproxy.FilterThrotllerHosts(backendHosts)
 				log.Debugf("Read %+v hosts from haproxy %s:%d/#%s", len(hosts), clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, poolName)
 				clusterProbes := &mysql.ClusterProbes{
 					ClusterName:          clusterName,


### PR DESCRIPTION
a more thorough parsing of the HAProxy status page: return not only the hosts relevant to `freno`, but also the complete list of backend hosts with their status.