### PR TITLE
collected metrics are cluster-aware

### DIFF
--- a/go/mysql/mysql_inventory.go
+++ b/go/mysql/mysql_inventory.go
@@ -6,10 +6,24 @@
 package mysql
 
 import (
+	"fmt"
 	"github.com/github/freno/go/base"
 )
 
-type InstanceMetricResultMap map[InstanceKey]base.MetricResult
+type ClusterInstanceKey struct {
+	ClusterName string
+	Key         InstanceKey
+}
+
+func GetClusterInstanceKey(clusterName string, key *InstanceKey) ClusterInstanceKey {
+	return ClusterInstanceKey{ClusterName: clusterName, Key: *key}
+}
+
+func (c ClusterInstanceKey) HashCode() string {
+	return fmt.Sprintf("%s:%s", c.ClusterName, c.Key.StringCode())
+}
+
+type InstanceMetricResultMap map[ClusterInstanceKey]base.MetricResult
 type ClusterInstanceHttpCheckResultMap map[string]int
 
 type MySQLInventory struct {
@@ -25,7 +39,7 @@ func NewMySQLInventory() *MySQLInventory {
 		ClustersProbes:            make(map[string](*Probes)),
 		IgnoreHostsCount:          make(map[string]int),
 		IgnoreHostsThreshold:      make(map[string]float64),
-		InstanceKeyMetrics:        make(map[InstanceKey]base.MetricResult),
+		InstanceKeyMetrics:        make(map[ClusterInstanceKey]base.MetricResult),
 		ClusterInstanceHttpChecks: make(map[string]int),
 	}
 	return inventory

--- a/go/throttle/mysql.go
+++ b/go/throttle/mysql.go
@@ -24,7 +24,7 @@ func aggregateMySQLProbes(
 		if clusterInstanceHttpChecksMap[mysql.MySQLHttpCheckHashKey(clusterName, &probe.Key)] == http.StatusNotFound {
 			continue
 		}
-		instanceMetricResult, ok := instanceResultsMap[probe.Key]
+		instanceMetricResult, ok := instanceResultsMap[mysql.GetClusterInstanceKey(clusterName, &probe.Key)]
 		if !ok {
 			return base.NoMetricResultYet
 		}

--- a/go/throttle/mysql_test.go
+++ b/go/throttle/mysql_test.go
@@ -30,12 +30,17 @@ func init() {
 
 func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 	clusterName := "c0"
+	key1cluster := mysql.GetClusterInstanceKey(clusterName, &key1)
+	key2cluster := mysql.GetClusterInstanceKey(clusterName, &key2)
+	key3cluster := mysql.GetClusterInstanceKey(clusterName, &key3)
+	key4cluster := mysql.GetClusterInstanceKey(clusterName, &key4)
+	key5cluster := mysql.GetClusterInstanceKey(clusterName, &key5)
 	instanceResultsMap := mysql.InstanceMetricResultMap{
-		key1: base.NewSimpleMetricResult(1.2),
-		key2: base.NewSimpleMetricResult(1.7),
-		key3: base.NewSimpleMetricResult(0.3),
-		key4: base.NewSimpleMetricResult(0.6),
-		key5: base.NewSimpleMetricResult(1.1),
+		key1cluster: base.NewSimpleMetricResult(1.2),
+		key2cluster: base.NewSimpleMetricResult(1.7),
+		key3cluster: base.NewSimpleMetricResult(0.3),
+		key4cluster: base.NewSimpleMetricResult(0.6),
+		key5cluster: base.NewSimpleMetricResult(1.1),
 	}
 	clusterInstanceHttpCheckResultMap := mysql.ClusterInstanceHttpCheckResultMap{
 		mysql.MySQLHttpCheckHashKey(clusterName, &key1): http.StatusOK,
@@ -45,8 +50,8 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 		mysql.MySQLHttpCheckHashKey(clusterName, &key5): http.StatusOK,
 	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
-	for key := range instanceResultsMap {
-		probes[key] = &mysql.Probe{Key: key}
+	for clusterKey := range instanceResultsMap {
+		probes[clusterKey.Key] = &mysql.Probe{Key: clusterKey.Key}
 	}
 	{
 		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false, 0)
@@ -88,12 +93,17 @@ func TestAggregateMySQLProbesNoErrors(t *testing.T) {
 
 func TestAggregateMySQLProbesNoErrorsIgnoreHostsThreshold(t *testing.T) {
 	clusterName := "c0"
+	key1cluster := mysql.GetClusterInstanceKey(clusterName, &key1)
+	key2cluster := mysql.GetClusterInstanceKey(clusterName, &key2)
+	key3cluster := mysql.GetClusterInstanceKey(clusterName, &key3)
+	key4cluster := mysql.GetClusterInstanceKey(clusterName, &key4)
+	key5cluster := mysql.GetClusterInstanceKey(clusterName, &key5)
 	instanceResultsMap := mysql.InstanceMetricResultMap{
-		key1: base.NewSimpleMetricResult(1.2),
-		key2: base.NewSimpleMetricResult(1.7),
-		key3: base.NewSimpleMetricResult(0.3),
-		key4: base.NewSimpleMetricResult(0.6),
-		key5: base.NewSimpleMetricResult(1.1),
+		key1cluster: base.NewSimpleMetricResult(1.2),
+		key2cluster: base.NewSimpleMetricResult(1.7),
+		key3cluster: base.NewSimpleMetricResult(0.3),
+		key4cluster: base.NewSimpleMetricResult(0.6),
+		key5cluster: base.NewSimpleMetricResult(1.1),
 	}
 	clusterInstanceHttpCheckResultMap := mysql.ClusterInstanceHttpCheckResultMap{
 		mysql.MySQLHttpCheckHashKey(clusterName, &key1): http.StatusOK,
@@ -103,8 +113,8 @@ func TestAggregateMySQLProbesNoErrorsIgnoreHostsThreshold(t *testing.T) {
 		mysql.MySQLHttpCheckHashKey(clusterName, &key5): http.StatusOK,
 	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
-	for key := range instanceResultsMap {
-		probes[key] = &mysql.Probe{Key: key}
+	for clusterKey := range instanceResultsMap {
+		probes[clusterKey.Key] = &mysql.Probe{Key: clusterKey.Key}
 	}
 	{
 		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false, 1.0)
@@ -146,12 +156,17 @@ func TestAggregateMySQLProbesNoErrorsIgnoreHostsThreshold(t *testing.T) {
 
 func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 	clusterName := "c0"
+	key1cluster := mysql.GetClusterInstanceKey(clusterName, &key1)
+	key2cluster := mysql.GetClusterInstanceKey(clusterName, &key2)
+	key3cluster := mysql.GetClusterInstanceKey(clusterName, &key3)
+	key4cluster := mysql.GetClusterInstanceKey(clusterName, &key4)
+	key5cluster := mysql.GetClusterInstanceKey(clusterName, &key5)
 	instanceResultsMap := mysql.InstanceMetricResultMap{
-		key1: base.NewSimpleMetricResult(1.2),
-		key2: base.NewSimpleMetricResult(1.7),
-		key3: base.NewSimpleMetricResult(0.3),
-		key4: base.NoSuchMetric,
-		key5: base.NewSimpleMetricResult(1.1),
+		key1cluster: base.NewSimpleMetricResult(1.2),
+		key2cluster: base.NewSimpleMetricResult(1.7),
+		key3cluster: base.NewSimpleMetricResult(0.3),
+		key4cluster: base.NoSuchMetric,
+		key5cluster: base.NewSimpleMetricResult(1.1),
 	}
 	clusterInstanceHttpCheckResultMap := mysql.ClusterInstanceHttpCheckResultMap{
 		mysql.MySQLHttpCheckHashKey(clusterName, &key1): http.StatusOK,
@@ -161,8 +176,8 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 		mysql.MySQLHttpCheckHashKey(clusterName, &key5): http.StatusOK,
 	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
-	for key := range instanceResultsMap {
-		probes[key] = &mysql.Probe{Key: key}
+	for clusterKey := range instanceResultsMap {
+		probes[clusterKey.Key] = &mysql.Probe{Key: clusterKey.Key}
 	}
 	{
 		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false, 0)
@@ -183,7 +198,7 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 		test.S(t).ExpectEquals(value, 1.2)
 	}
 
-	instanceResultsMap[key1] = base.NoSuchMetric
+	instanceResultsMap[key1cluster] = base.NoSuchMetric
 	{
 		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false, 0)
 		_, err := worstMetric.Get()
@@ -206,12 +221,17 @@ func TestAggregateMySQLProbesWithErrors(t *testing.T) {
 
 func TestAggregateMySQLProbesWithHttpChecks(t *testing.T) {
 	clusterName := "c0"
+	key1cluster := mysql.GetClusterInstanceKey(clusterName, &key1)
+	key2cluster := mysql.GetClusterInstanceKey(clusterName, &key2)
+	key3cluster := mysql.GetClusterInstanceKey(clusterName, &key3)
+	key4cluster := mysql.GetClusterInstanceKey(clusterName, &key4)
+	key5cluster := mysql.GetClusterInstanceKey(clusterName, &key5)
 	instanceResultsMap := mysql.InstanceMetricResultMap{
-		key1: base.NewSimpleMetricResult(1.2),
-		key2: base.NewSimpleMetricResult(1.7),
-		key3: base.NewSimpleMetricResult(0.3),
-		key4: base.NoSuchMetric,
-		key5: base.NewSimpleMetricResult(1.1),
+		key1cluster: base.NewSimpleMetricResult(1.2),
+		key2cluster: base.NewSimpleMetricResult(1.7),
+		key3cluster: base.NewSimpleMetricResult(0.3),
+		key4cluster: base.NoSuchMetric,
+		key5cluster: base.NewSimpleMetricResult(1.1),
 	}
 	clusterInstanceHttpCheckResultMap := mysql.ClusterInstanceHttpCheckResultMap{
 		mysql.MySQLHttpCheckHashKey(clusterName, &key1): http.StatusOK,
@@ -221,8 +241,8 @@ func TestAggregateMySQLProbesWithHttpChecks(t *testing.T) {
 		mysql.MySQLHttpCheckHashKey(clusterName, &key5): http.StatusOK,
 	}
 	var probes mysql.Probes = map[mysql.InstanceKey](*mysql.Probe){}
-	for key := range instanceResultsMap {
-		probes[key] = &mysql.Probe{Key: key}
+	for clusterKey := range instanceResultsMap {
+		probes[clusterKey.Key] = &mysql.Probe{Key: clusterKey.Key}
 	}
 	{
 		worstMetric := aggregateMySQLProbes(&probes, clusterName, instanceResultsMap, clusterInstanceHttpCheckResultMap, 0, false, 0)


### PR DESCRIPTION
Fixes https://github.com/github/freno/issues/87

`freno` should store MySQL metric results in cluster-ware context. Today the metrics are stored based on `InstanceKey`: hostname+port.

But it is possible for same instance to participate in multiple pools, which have different metrics. Thus, a "cluster" context is now added.