### PR TITLE
MySQL backend as alternative to raft quorum

### DIFF
--- a/go/cmd/freno/main.go
+++ b/go/cmd/freno/main.go
@@ -101,22 +101,20 @@ func loadConfiguration(configFile string) {
 }
 
 func httpServe() error {
-	throttler := throttle.NewThrottler(group.IsLeader)
+	throttler := throttle.NewThrottler()
 	log.Infof("Starting consensus service")
-	consensusService, err := group.Setup(throttler)
+	consensusServiceProvider, err := group.NewConsensusServiceProvider(throttler)
 	if err != nil {
 		return err
 	}
-	_, err = group.NewMySQLBackend(throttler)
-	if err != nil {
-		log.Errore(err)
-	}
-	go group.Monitor()
+	throttler.SetLeaderFunc(consensusServiceProvider.GetConsensusService().IsLeader)
+
+	go consensusServiceProvider.Monitor()
 	go throttler.Operate()
 
 	throttlerCheck := throttle.NewThrottlerCheck(throttler)
 	throttlerCheck.SelfChecks()
-	api := http.NewAPIImpl(throttlerCheck, consensusService)
+	api := http.NewAPIImpl(throttlerCheck, consensusServiceProvider.GetConsensusService())
 	router := http.ConfigureRoutes(api)
 	port := config.Settings().ListenPort
 	log.Infof("Starting server in port %d", port)

--- a/go/cmd/freno/main.go
+++ b/go/cmd/freno/main.go
@@ -107,6 +107,10 @@ func httpServe() error {
 	if err != nil {
 		return err
 	}
+	_, err = group.NewMySQLBackend(throttler)
+	if err != nil {
+		log.Errore(err)
+	}
 	go group.Monitor()
 	go throttler.Operate()
 

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -115,9 +115,9 @@ func newConfigurationSettings() *ConfigurationSettings {
 		RaftBind:           "127.0.0.1:10008",
 		RaftDataDir:        "",
 		DefaultRaftPort:    0,
+		RaftNodes:          []string{},
 		BackendMySQLHost:   "",
 		BackendMySQLSchema: "",
-		RaftNodes:          []string{},
 		BackendMySQLPort:   3306,
 		MemcacheServers:    []string{},
 		MemcachePath:       "freno",
@@ -130,9 +130,6 @@ func newConfigurationSettings() *ConfigurationSettings {
 
 // Hook to implement adjustments after reading each configuration file.
 func (settings *ConfigurationSettings) postReadAdjustments() error {
-	if settings.RaftDataDir == "" {
-		return fmt.Errorf("RaftDataDir must be set")
-	}
 	if submatch := envVariableRegexp.FindStringSubmatch(settings.BackendMySQLHost); len(submatch) > 1 {
 		settings.BackendMySQLHost = os.Getenv(submatch[1])
 	}
@@ -144,6 +141,9 @@ func (settings *ConfigurationSettings) postReadAdjustments() error {
 	}
 	if submatch := envVariableRegexp.FindStringSubmatch(settings.BackendMySQLPassword); len(submatch) > 1 {
 		settings.BackendMySQLPassword = os.Getenv(submatch[1])
+	}
+	if settings.RaftDataDir == "" && settings.BackendMySQLHost == "" {
+		return fmt.Errorf("Either RaftDataDir or BackendMySQLHost must be set")
 	}
 	if settings.BackendMySQLHost != "" {
 		if settings.BackendMySQLSchema == "" {

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -92,25 +92,35 @@ func (config *Configuration) Reload() error {
 // Some of the settinges have reasonable default values, and some other
 // (like database credentials) are strictly expected from user.
 type ConfigurationSettings struct {
-	ListenPort      int
-	RaftBind        string
-	RaftDataDir     string
-	DefaultRaftPort int      // if a RaftNodes entry does not specify port, use this one
-	RaftNodes       []string // Raft nodes to make initial connection with
-	MemcacheServers []string // if given, freno will report to aggregated values to given memcache
-	MemcachePath    string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
-	Stores          StoresSettings
+	ListenPort           int
+	DataCenter           string
+	Environment          string
+	RaftBind             string
+	RaftDataDir          string
+	DefaultRaftPort      int      // if a RaftNodes entry does not specify port, use this one
+	RaftNodes            []string // Raft nodes to make initial connection with
+	BackendMySQLHost     string
+	BackendMySQLPort     int
+	BackendMySQLSchema   string
+	BackendMySQLUser     string
+	BackendMySQLPassword string
+	MemcacheServers      []string // if given, freno will report to aggregated values to given memcache
+	MemcachePath         string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
+	Stores               StoresSettings
 }
 
 func newConfigurationSettings() *ConfigurationSettings {
 	return &ConfigurationSettings{
-		ListenPort:      8087,
-		RaftBind:        "127.0.0.1:10008",
-		RaftDataDir:     "",
-		DefaultRaftPort: 0,
-		RaftNodes:       []string{},
-		MemcacheServers: []string{},
-		MemcachePath:    "freno",
+		ListenPort:         8087,
+		RaftBind:           "127.0.0.1:10008",
+		RaftDataDir:        "",
+		DefaultRaftPort:    0,
+		BackendMySQLHost:   "",
+		BackendMySQLSchema: "",
+		RaftNodes:          []string{},
+		BackendMySQLPort:   3306,
+		MemcacheServers:    []string{},
+		MemcachePath:       "freno",
 		//Debug:                                        false,
 		//ListenSocket:                                 "",
 		//AnExampleListOfStrings:                       []string{"*"},
@@ -122,6 +132,11 @@ func newConfigurationSettings() *ConfigurationSettings {
 func (settings *ConfigurationSettings) postReadAdjustments() error {
 	if settings.RaftDataDir == "" {
 		return fmt.Errorf("RaftDataDir must be set")
+	}
+	if settings.BackendMySQLHost != "" {
+		if settings.BackendMySQLSchema == "" {
+			return fmt.Errorf("BackendMySQLSchema must be set when BackendMySQLHost is specified")
+		}
 	}
 	if err := settings.Stores.postReadAdjustments(); err != nil {
 		return err

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -133,6 +133,18 @@ func (settings *ConfigurationSettings) postReadAdjustments() error {
 	if settings.RaftDataDir == "" {
 		return fmt.Errorf("RaftDataDir must be set")
 	}
+	if submatch := envVariableRegexp.FindStringSubmatch(settings.BackendMySQLHost); len(submatch) > 1 {
+		settings.BackendMySQLHost = os.Getenv(submatch[1])
+	}
+	if submatch := envVariableRegexp.FindStringSubmatch(settings.BackendMySQLSchema); len(submatch) > 1 {
+		settings.BackendMySQLSchema = os.Getenv(submatch[1])
+	}
+	if submatch := envVariableRegexp.FindStringSubmatch(settings.BackendMySQLUser); len(submatch) > 1 {
+		settings.BackendMySQLUser = os.Getenv(submatch[1])
+	}
+	if submatch := envVariableRegexp.FindStringSubmatch(settings.BackendMySQLPassword); len(submatch) > 1 {
+		settings.BackendMySQLPassword = os.Getenv(submatch[1])
+	}
 	if settings.BackendMySQLHost != "" {
 		if settings.BackendMySQLSchema == "" {
 			return fmt.Errorf("BackendMySQLSchema must be set when BackendMySQLHost is specified")

--- a/go/group/consensus.go
+++ b/go/group/consensus.go
@@ -1,0 +1,17 @@
+package group
+
+import (
+	"github.com/github/freno/go/throttle"
+	"github.com/outbrain/golib/log"
+)
+
+func Setup(throttler *throttle.Throttler) (ConsensusService, error) {
+	consensusService, err := SetupRaft(throttler)
+	if err != nil {
+		return consensusService, err
+	}
+	if _, err := NewMySQLBackend(throttler); err != nil {
+		log.Errore(err)
+	}
+	return consensusService, err
+}

--- a/go/group/consensus.go
+++ b/go/group/consensus.go
@@ -1,17 +1,50 @@
 package group
 
 import (
+	"github.com/github/freno/go/config"
 	"github.com/github/freno/go/throttle"
 	"github.com/outbrain/golib/log"
 )
 
-func Setup(throttler *throttle.Throttler) (ConsensusService, error) {
-	consensusService, err := SetupRaft(throttler)
-	if err != nil {
-		return consensusService, err
+type ConsensusServiceProvider struct {
+	mySQLConsensusService ConsensusService
+	raftConsensusService  ConsensusService
+}
+
+func NewConsensusServiceProvider(throttler *throttle.Throttler) (p *ConsensusServiceProvider, err error) {
+	p = &ConsensusServiceProvider{}
+
+	if config.Settings().RaftDataDir != "" {
+		if p.raftConsensusService, err = SetupRaft(throttler); err != nil {
+			log.Errore(err)
+		}
 	}
-	if _, err := NewMySQLBackend(throttler); err != nil {
-		log.Errore(err)
+	if config.Settings().BackendMySQLHost != "" {
+		if p.mySQLConsensusService, err = NewMySQLBackend(throttler); err != nil {
+			log.Errore(err)
+		}
 	}
-	return consensusService, err
+	if p.raftConsensusService == nil && p.mySQLConsensusService == nil {
+		return nil, log.Errorf("Could not create any consensus service")
+	}
+	return p, nil
+}
+
+func (p *ConsensusServiceProvider) GetConsensusService() ConsensusService {
+	if p.raftConsensusService != nil {
+		return p.raftConsensusService
+	}
+	if p.mySQLConsensusService != nil {
+		return p.mySQLConsensusService
+	}
+	return nil
+}
+
+func (p *ConsensusServiceProvider) Monitor() {
+	if p.raftConsensusService != nil {
+		go p.raftConsensusService.Monitor()
+	}
+	if p.mySQLConsensusService != nil {
+		go p.mySQLConsensusService.Monitor()
+	}
 }

--- a/go/group/consensus_service.go
+++ b/go/group/consensus_service.go
@@ -6,6 +6,8 @@ import (
 	"github.com/github/freno/go/base"
 )
 
+const monitorInterval = 5 * time.Second
+
 // ConsensusService is a freno-oriented interface for making requests that require consensus.
 type ConsensusService interface {
 	ThrottleApp(appName string, ttlMinutes int64, expireAt time.Time, ratio float64) error
@@ -13,6 +15,7 @@ type ConsensusService interface {
 	UnthrottleApp(appName string) error
 	RecentAppsMap() (result map[string](*base.RecentApp))
 
+	IsHealthy() bool
 	IsLeader() bool
 	GetLeader() string
 	GetStateDescription() string

--- a/go/group/consensus_service.go
+++ b/go/group/consensus_service.go
@@ -12,4 +12,10 @@ type ConsensusService interface {
 	ThrottledAppsMap() (result map[string](*base.AppThrottle))
 	UnthrottleApp(appName string) error
 	RecentAppsMap() (result map[string](*base.RecentApp))
+
+	IsLeader() bool
+	GetLeader() string
+	GetStateDescription() string
+
+	Monitor()
 }

--- a/go/group/consensus_service.go
+++ b/go/group/consensus_service.go
@@ -8,7 +8,7 @@ import (
 
 // ConsensusService is a freno-oriented interface for making requests that require consensus.
 type ConsensusService interface {
-	ThrottleApp(appName string, expireAt time.Time, ratio float64) error
+	ThrottleApp(appName string, ttlMinutes int64, expireAt time.Time, ratio float64) error
 	ThrottledAppsMap() (result map[string](*base.AppThrottle))
 	UnthrottleApp(appName string) error
 	RecentAppsMap() (result map[string](*base.RecentApp))

--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -1,0 +1,110 @@
+// Provide a MySQL backend as alternative to raft consensus
+
+// Expect the following backend tables:
+/*
+
+CREATE TABLE service_election (
+  domain varchar(32) NOT NULL,
+  service_id varchar(128) NOT NULL,
+  last_seen_active timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (domain)
+);
+
+
+*/
+package group
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	"github.com/github/freno/go/config"
+
+	"github.com/outbrain/golib/sqlutils"
+)
+
+type MySQLBackend struct {
+	db        *sql.DB
+	domain    string
+	serviceId string
+}
+
+const maxConnections = 3
+
+func NewMySQLBackend() (*MySQLBackend, error) {
+	if config.Settings().BackendMySQLHost == "" {
+		return nil, nil
+	}
+	dbUri := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&charset=utf8mb4,utf8,latin1&timeout=500ms",
+		config.Settings().BackendMySQLUser, config.Settings().BackendMySQLPassword, config.Settings().BackendMySQLHost, config.Settings().BackendMySQLPort, config.Settings().BackendMySQLSchema,
+	)
+	db, _, err := sqlutils.GetDB(dbUri)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(maxConnections)
+	db.SetMaxIdleConns(maxConnections)
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	return &MySQLBackend{
+		db:        db,
+		domain:    fmt.Sprintf("%s:%s", config.Settings().DataCenter, config.Settings().Environment),
+		serviceId: hostname,
+	}, nil
+}
+
+func (backend *MySQLBackend) AttemptLeadership() error {
+	query := `
+    insert ignore into service_election (
+        domain, service_id, last_seen_active
+      ) values (
+        ?, ?, now()
+      ) on duplicate key update
+      service_id = if(last_seen_active < now() - interval 20 second, values(service_id), service_id),
+      last_seen_active = if(service_id = values(service_id), values(last_seen_active), last_seen_active)
+  `
+	args := sqlutils.Args(backend.domain, backend.serviceId)
+	_, err := sqlutils.ExecNoPrepare(backend.db, query, args...)
+	return err
+}
+
+func (backend *MySQLBackend) ForceLeadership() error {
+	query := `
+    replace into service_election (
+        domain, service_id, last_seen_active
+      ) values (
+        ?, ?, now()
+      )
+  `
+	args := sqlutils.Args(backend.domain, backend.serviceId)
+	_, err := sqlutils.ExecNoPrepare(backend.db, query, args...)
+	return err
+}
+
+func (backend *MySQLBackend) Reelect() error {
+	query := `
+    delete from service_election where domain=?
+  `
+	args := sqlutils.Args(backend.domain)
+	_, err := sqlutils.ExecNoPrepare(backend.db, query, args...)
+	return err
+}
+
+func (backend *MySQLBackend) IsLeader() (bool, error) {
+	query := `
+    select count(*)
+      from service_election
+      where domain=?
+      and service_id=?
+  `
+	args := sqlutils.Args(backend.domain, backend.serviceId)
+
+	var count int
+	err := backend.db.QueryRow(query, args).Scan(&count)
+
+	return (count > 0), err
+}

--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -77,13 +77,6 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 	return backend, nil
 }
 
-func boolToInt64(b bool) int64 {
-	if b {
-		return 1
-	}
-	return 0
-}
-
 // Monitor is a utility function to routinely observe leadership state.
 // It doesn't actually do much; merely takes notes.
 func (backend *MySQLBackend) continuousElections() {

--- a/go/group/raft.go
+++ b/go/group/raft.go
@@ -27,7 +27,7 @@ var store *Store
 
 // Setup creates the entire raft shananga. Creates the store, associates with the throttler,
 // contacts peer nodes, and subscribes to leader changes to export them.
-func Setup(throttler *throttle.Throttler) (ConsensusService, error) {
+func SetupRaft(throttler *throttle.Throttler) (ConsensusService, error) {
 	store = NewStore(config.Settings().RaftDataDir, normalizeRaftNode(config.Settings().RaftBind), throttler)
 
 	peerNodes := []string{}

--- a/go/group/store.go
+++ b/go/group/store.go
@@ -7,6 +7,7 @@ package group
 
 import (
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"net"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/raft-boltdb"
 	"github.com/outbrain/golib/log"
+	metrics "github.com/rcrowley/go-metrics"
 )
 
 const (
@@ -173,4 +175,62 @@ func (store *Store) Join(addr string) error {
 	}
 	log.Infof("node at %s joined successfully", addr)
 	return nil
+}
+
+// IsLeader tells if this node is the current raft leader
+func (store *Store) IsLeader() bool {
+	return store.GetState() == raft.Leader
+}
+
+// GetLeader returns identity of raft leader
+func (store *Store) GetLeader() string {
+	return getRaft().Leader()
+}
+
+// GetState returns current raft state
+func (store *Store) GetState() raft.RaftState {
+	return getRaft().State()
+}
+
+// GetState returns current raft state
+func (store *Store) GetStateDescription() string {
+	return store.GetState().String()
+}
+
+// Monitor is a utility function to routinely observe leadership state.
+// It doesn't actually do much; merely takes notes.
+func (store *Store) Monitor() {
+	t := time.NewTicker(5 * time.Second)
+
+	for {
+		select {
+		case <-t.C:
+			leaderHint := store.GetLeader()
+
+			leaderExpVar := expvar.Get("raft.leader")
+			if leaderExpVar == nil {
+				leaderExpVar = expvar.NewString("raft.leader")
+			}
+			leaderExpVar.(*expvar.String).Set(leaderHint)
+
+			state := store.GetState()
+			if state == raft.Leader {
+				leaderHint = fmt.Sprintf("%s (this host)", leaderHint)
+				metrics.GetOrRegisterGauge("raft.is_leader", nil).Update(1)
+			} else {
+				metrics.GetOrRegisterGauge("raft.is_leader", nil).Update(0)
+			}
+			switch state {
+			case raft.Leader, raft.Follower:
+				{
+					metrics.GetOrRegisterGauge("raft.is_healthy", nil).Update(1)
+				}
+			default:
+				{
+					metrics.GetOrRegisterGauge("raft.is_healthy", nil).Update(0)
+				}
+			}
+			log.Debugf("raft leader is %s; state: %s", leaderHint, state.String())
+		}
+	}
 }

--- a/go/group/store.go
+++ b/go/group/store.go
@@ -134,7 +134,7 @@ func (store *Store) genericCommand(c *command) error {
 
 // ThrottleApp, as implied by consensusService, is a raft oepration request which
 // will ask for consensus.
-func (store *Store) ThrottleApp(appName string, expireAt time.Time, ratio float64) error {
+func (store *Store) ThrottleApp(appName string, ttlMinutes int64, expireAt time.Time, ratio float64) error {
 	c := &command{
 		Operation: "throttle",
 		Key:       appName,

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -233,7 +233,7 @@ func (api *APIImpl) ThrottleApp(w http.ResponseWriter, r *http.Request, ps httpr
 		err = fmt.Errorf("ratio must be in [0..1] range; got %+v", ratio)
 		goto response
 	}
-	err = api.consensusService.ThrottleApp(appName, expireAt, ratio)
+	err = api.consensusService.ThrottleApp(appName, ttlMinutes, expireAt, ratio)
 
 response:
 	api.respondGeneric(w, r, err)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -95,7 +95,7 @@ func (api *APIImpl) LbCheck(w http.ResponseWriter, r *http.Request, _ httprouter
 // This is a useful check for HAProxy routing
 func (api *APIImpl) LeaderCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	statusCode := http.StatusNotFound
-	if group.IsLeader() {
+	if api.consensusService.IsLeader() {
 		statusCode = http.StatusOK
 	}
 	w.WriteHeader(statusCode)
@@ -106,7 +106,7 @@ func (api *APIImpl) LeaderCheck(w http.ResponseWriter, r *http.Request, _ httpro
 
 // RaftLeader returns the identity of the leader
 func (api *APIImpl) RaftLeader(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	if leader := group.GetLeader(); leader != "" {
+	if leader := api.consensusService.GetLeader(); leader != "" {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(leader)
 	} else {
@@ -116,7 +116,7 @@ func (api *APIImpl) RaftLeader(w http.ResponseWriter, r *http.Request, _ httprou
 
 // RaftState returns the state of the raft node
 func (api *APIImpl) RaftState(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	json.NewEncoder(w).Encode(group.GetState().String())
+	json.NewEncoder(w).Encode(api.consensusService.GetStateDescription())
 }
 
 // Hostname returns the hostname this process executes on
@@ -322,6 +322,8 @@ func ConfigureRoutes(api API) *httprouter.Router {
 	register(router, "/leader-check", api.LeaderCheck)
 	register(router, "/raft/leader", api.RaftLeader)
 	register(router, "/raft/state", api.RaftState)
+	// register(router, "/consensus/leader", api.ConsensusLeader)
+	// register(router, "/consensus/state", api.ConsensusState)
 	register(router, "/hostname", api.Hostname)
 
 	register(router, "/check/:app/:storeType/:storeName", api.WriteCheck)

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -62,10 +62,9 @@ type Throttler struct {
 	throttledAppsMutex sync.Mutex
 }
 
-func NewThrottler(isLeaderFunc func() bool) *Throttler {
+func NewThrottler() *Throttler {
 	throttler := &Throttler{
-		isLeader:     false,
-		isLeaderFunc: isLeaderFunc,
+		isLeader: false,
 
 		mysqlThrottleMetricChan: make(chan *mysql.MySQLThrottleMetric),
 		mysqlHttpCheckChan:      make(chan *mysql.MySQLHttpCheck),
@@ -87,6 +86,10 @@ func NewThrottler(isLeaderFunc func() bool) *Throttler {
 	throttler.memcachePath = config.Settings().MemcachePath
 
 	return throttler
+}
+
+func (throttler *Throttler) SetLeaderFunc(isLeaderFunc func() bool) {
+	throttler.isLeaderFunc = isLeaderFunc
 }
 
 func (throttler *Throttler) ThrottledAppsSnapshot() map[string]cache.Item {

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -32,7 +32,7 @@ const aggregatedMetricsCleanup = 1 * time.Second
 const throttledAppsSnapshotInterval = 5 * time.Second
 const recentAppsExpiration = time.Hour * 24
 
-const defaultThrottleTTL = 60 * time.Minute
+const DefaultThrottleTTLMinutes = 60
 const DefaultThrottleRatio = 1.0
 
 func init() {
@@ -420,7 +420,7 @@ func (throttler *Throttler) ThrottleApp(appName string, expireAt time.Time, rati
 		}
 	} else {
 		if expireAt.IsZero() {
-			expireAt = now.Add(defaultThrottleTTL)
+			expireAt = now.Add(DefaultThrottleTTLMinutes * time.Minute)
 		}
 		if ratio < 0 {
 			ratio = DefaultThrottleRatio


### PR DESCRIPTION
This PR offers statefulness and leadership via shared MySQL backend, as an alternative to the raft setup.

Some notes:

- Either `raft` or `mysql` are used. Provide one of:
  - `RaftDataDir`
  - `BackendMySQLHost`
  there is no seamless transition of data between the two.
  If both are defined: WIP
- This adds dependency on a MySQL backend
- The number of `freno` services can now be arbitrary. Raft requires 3 or more, but not much more. With MySQL backend 2 is also good.
- This simplifies deployments on `k8s` 
- `freno` only accesses a MySQL master and does not read from replicas. The load is places is very low.
- With `Datacenter` and `Environment` configuration variables, `freno` builds a "domain". Multiple `freno` clusters can all use same MySQL backend, if on different DCs or environments. E.g., a domain might be "my-1st-datacenter:production".
- Adds `backend.mysql.is_healthy` and `backend.mysql.is_leader` metrics.
- Adds more generic `consensus.is_healthy` and `consensus.is_leader` metrics. These should generally be used by monitoring.
  - `freno` will populate these values either from `raft` or from `mysql`, depending on config.

Requires these two backend tables:

```

CREATE TABLE service_election (
  domain varchar(32) NOT NULL,
  service_id varchar(128) NOT NULL,
  last_seen_active timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (domain)
);

CREATE TABLE throttled_apps (
  app_name varchar(128) NOT NULL,
	throttled_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
  expires_at TIMESTAMP NOT NULL,
	ratio DOUBLE,
  PRIMARY KEY (app_name)
);
```

cc @github/database-infrastructure 