### PR TITLE
Adding Apps.Deprioritized config and logic

### DIFF
--- a/go/config/app_config.go
+++ b/go/config/app_config.go
@@ -1,0 +1,14 @@
+package config
+
+//
+// General-store configuration
+//
+
+type AppSettings struct {
+	Deprioritized []string // list of deprioritized app names
+}
+
+// Hook to implement adjustments after reading each configuration file.
+func (settings *AppSettings) postReadAdjustments() error {
+	return nil
+}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -100,6 +100,7 @@ type ConfigurationSettings struct {
 	MemcacheServers []string // if given, freno will report to aggregated values to given memcache
 	MemcachePath    string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
 	Stores          StoresSettings
+	Apps            AppSettings
 }
 
 func newConfigurationSettings() *ConfigurationSettings {
@@ -124,6 +125,9 @@ func (settings *ConfigurationSettings) postReadAdjustments() error {
 		return fmt.Errorf("RaftDataDir must be set")
 	}
 	if err := settings.Stores.postReadAdjustments(); err != nil {
+		return err
+	}
+	if err := settings.Apps.postReadAdjustments(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This PR adds config and logic to handle "deprioritized" apps. This introduces a special behavior whenever a deprioritized app issues `check` request.

The use case are jobs like `pt-archiver` which compete for resources with more important parts of the application. The logic is as follows:

- whenever a "normal" app (one which is not deprioritizes) gets throttled because of threshold overflow (use case: replication lag exceeded), all "deprioritized" apps are auto rejected for the next `1 second`.

How this is expected to behave:

- In a scenario where a "normal" app is checking `freno` and routinely gets a `200`, there is no change in behavior. All apps including deprioritized ones are equally evaluated, and we can expect all apps to make progress.
- As soon as a "normal" app gets rejected due to threshold, all deprioritized apps get rejected in the next `1sec` no matter what. Other "normal" apps continue to get the normal response, which is based on threshold etc.
- In a scenario where a "normal" app is heavily writing, we can expect `freno` to routinely return with `HTTP 200` and `HTTP 429`, because the app keeps pushing the threshold (e.g. causes replication lag, gets pushed back by freno, lag receeds, gets approved by freno, keeps writing, generated replication lag, ..., and so forth).
  In this scenario we can expect deprioritized apps to be _continuously rejected_.

cc @github/database-infrastructure @latentflip ; reminder that this is a public repo.
