### PR TITLE
MySQL backend takes higher priority than raft consensus

### DIFF
--- a/doc/high-availability.md
+++ b/doc/high-availability.md
@@ -1,60 +1,19 @@
 # High Availability
 
-`freno` is a highly available service that uses the `raft` consensus protocol to coordinate between multiple running nodes. There is a single leader node which probes data from backend stores. When the leader steps down, another takes its place. For the first few seconds it would refuse connections (stepping up as `raft` leader will take a couple seconds) and it will likely have no metrics to share. Within a few seconds it will have all the info it needs to serve.
+`freno` offers two alternate methods for high availability:
 
-Events/commands passed to one node are shared via `raft` consensus to other nodes; a newly promoted leader would have all the necessary events to pick up from the place the previous leader stepped down.
+1. [raft](raft.md) consensus, where `freno` nodes are all `raft` nodes and coordinate state with each other.
+2. [MySQL](mysql-backend.md) based, where `freno` uses a `MySQL` backend for state and leadership resolution. In this setup `freno` assumes `MySQL` is available.
 
-### The setup
+MySQL backend adds MySQL as a dependency, and also requires the user to maintain high availability for MySQL itself. It makes sense in environments where MySQL HA is a solved problem.
 
-`raft` recommended number of nodes is `3` or `5`. All `freno` nodes are `raft` members.
+`raft` has less dependencies, but is also more difficult to deploy on some setups, namely Kubernetes, because of the strict need for nodes to explicitly know each other by name/IP.
 
-The following depicts a possible setup to provide with `freno` high availability:
+### Force leadership
 
-- `3` or `5` (say `n`) `freno` nodes.
-- On each node, configure `"RaftNodes"` to list all `n` nodes (this includes the local node). Use IP addresses.
-  - What we get: `n` nodes talking to each other, one of them becoming _leader_. Only the leader collects data hence is the only one that can actually serve client checks.
-- HAProxy in front of `freno` nodes.
-  - HAProxy only directs traffic to the _leader_. `freno` has specialized `/leader-check`.
-  - Sample HAProxy configuration can be found in [haproxy.cfg](../resources/haproxy.cfg)
-- Clients to talk to HAProxy
-  - Implicitly, all clients only talk to the _leader_
+It is possible to instruct a `freno` daemon to assume it is the leader, no matter what consensus says.
 
-### Raft
+- Provide the `--force-leadership` flag.
+- This does not affect other nodes. Another node may _also_ believe its the leader, either because of consensus or because of similar configuration.
 
-`freno` is a `Go` project. It uses the [Hashicorp](https://github.com/hashicorp/raft) raft implementation, with [Bolt](https://github.com/boltdb/bolt) as backend store.
-
-`freno` stores the `Bolt` data in `freno-raft.db`, under the `RaftDataDir` path as defined in config file.
-
-
-### Configuration
-
-Let's dissect the general section of the [sample config file](../resources/freno.conf.sample.json):
-
-
-```
-{
-  "ListenPort": 9777,
-  "DefaultRaftPort": 9888,
-  "RaftDataDir": "/var/lib/freno",
-  "RaftBind": "10.0.0.1",
-  "RaftNodes": ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
-}
-```
-
-- `ListenPort` is the `HTTP` port where `freno` will serve. Will be exposed to the user, or better yet, to HAProxy as suggested above.
-- `DefaultRaftPort` is the internal `raft` port, used for consensus communication. Need not be exposed to the user.
-- `RaftDataDir`: local directory where `freno` stores `raft` data, under `freno-raft.db`
-- `RaftBind`: where `raft` should listen on.
-- `RaftNodes`: complete list of `raft` members. At this time this list is not dynamic.
-
-Using IP addresses seems to work better than hostnames.
-
-### Single node mode
-
-It is possible to run `freno` as a single node service (meaning no high availability). To do that, provide the following in the config file:
-
-```
-  "RaftNodes": []
-```
-
-i.e. declare no nodes at all. `freno` will still run with `raft` consensus, but will be considered as a standalone node. It will benefit from `raft` event persistence, and dynamic changes will survive a node restart.
+This flag can be used in emergency cases where consensus cannot be established, due to hardware/network issues.

--- a/doc/raft.md
+++ b/doc/raft.md
@@ -1,0 +1,62 @@
+# Raft
+
+This documents how `freno` achieves high availability and consistent state via `raft` consensus. As an alternative, see [MySQL backend](mysql-backend.md).
+
+`freno` is a highly available service that uses the `raft` consensus protocol to coordinate between multiple running nodes. There is a single leader node which probes data from backend stores. When the leader steps down, another takes its place. For the first few seconds it would refuse connections (stepping up as `raft` leader will take a couple seconds) and it will likely have no metrics to share. Within a few seconds it will have all the info it needs to serve.
+
+Events/commands passed to one node are shared via `raft` consensus to other nodes; a newly promoted leader would have all the necessary events to pick up from the place the previous leader stepped down.
+
+### The setup
+
+`raft` recommended number of nodes is `3` or `5`. All `freno` nodes are `raft` members.
+
+The following depicts a possible setup to provide with `freno` high availability:
+
+- `3` or `5` (say `n`) `freno` nodes.
+- On each node, configure `"RaftNodes"` to list all `n` nodes (this includes the local node). Use IP addresses.
+  - What we get: `n` nodes talking to each other, one of them becoming _leader_. Only the leader collects data hence is the only one that can actually serve client checks.
+- HAProxy in front of `freno` nodes.
+  - HAProxy only directs traffic to the _leader_. `freno` has specialized `/leader-check`.
+  - Sample HAProxy configuration can be found in [haproxy.cfg](../resources/haproxy.cfg)
+- Clients to talk to HAProxy
+  - Implicitly, all clients only talk to the _leader_
+
+### Raft
+
+`freno` is a `Go` project. It uses the [Hashicorp](https://github.com/hashicorp/raft) raft implementation, with [Bolt](https://github.com/boltdb/bolt) as backend store.
+
+`freno` stores the `Bolt` data in `freno-raft.db`, under the `RaftDataDir` path as defined in config file.
+
+
+### Configuration
+
+Let's dissect the general section of the [sample config file](../resources/freno.conf.sample.json):
+
+
+```
+{
+  "ListenPort": 9777,
+  "DefaultRaftPort": 9888,
+  "RaftDataDir": "/var/lib/freno",
+  "RaftBind": "10.0.0.1",
+  "RaftNodes": ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+}
+```
+
+- `ListenPort` is the `HTTP` port where `freno` will serve. Will be exposed to the user, or better yet, to HAProxy as suggested above.
+- `DefaultRaftPort` is the internal `raft` port, used for consensus communication. Need not be exposed to the user.
+- `RaftDataDir`: local directory where `freno` stores `raft` data, under `freno-raft.db`
+- `RaftBind`: where `raft` should listen on.
+- `RaftNodes`: complete list of `raft` members. At this time this list is not dynamic.
+
+Using IP addresses seems to work better than hostnames.
+
+### Single node mode
+
+It is possible to run `freno` as a single node service (meaning no high availability). To do that, provide the following in the config file:
+
+```
+  "RaftNodes": []
+```
+
+i.e. declare no nodes at all. `freno` will still run with `raft` consensus, but will be considered as a standalone node. It will benefit from `raft` event persistence, and dynamic changes will survive a node restart.

--- a/go/cmd/freno/main.go
+++ b/go/cmd/freno/main.go
@@ -31,6 +31,8 @@ func main() {
 	raftBind := flag.String("raft-bind", "", "Raft bind address (example: '127.0.0.1:10008'). Overrides config's RaftBind")
 	raftNodes := flag.String("raft-nodes", "", "Comma separated (e.g. 'host:port[,host:port]') list of raft nodes. Overrides config's RaftNodes")
 
+	group.ForceLeadership = *flag.Bool("force-leadership", false, "Make this node consider itself a leader no matter what consensus logic says")
+
 	quiet := flag.Bool("quiet", false, "quiet")
 	verbose := flag.Bool("verbose", false, "verbose")
 	debug := flag.Bool("debug", false, "debug mode (very verbose)")

--- a/go/group/consensus.go
+++ b/go/group/consensus.go
@@ -41,21 +41,21 @@ func NewConsensusServiceProvider(throttler *throttle.Throttler) (p *ConsensusSer
 }
 
 func (p *ConsensusServiceProvider) GetConsensusService() ConsensusService {
-	if p.raftConsensusService != nil {
-		return p.raftConsensusService
-	}
 	if p.mySQLConsensusService != nil {
 		return p.mySQLConsensusService
+	}
+	if p.raftConsensusService != nil {
+		return p.raftConsensusService
 	}
 	return nil
 }
 
 func (p *ConsensusServiceProvider) Monitor() {
-	if p.raftConsensusService != nil {
-		go p.raftConsensusService.Monitor()
-	}
 	if p.mySQLConsensusService != nil {
 		go p.mySQLConsensusService.Monitor()
+	}
+	if p.raftConsensusService != nil {
+		go p.raftConsensusService.Monitor()
 	}
 
 	t := time.NewTicker(monitorInterval)

--- a/go/group/consensus.go
+++ b/go/group/consensus.go
@@ -9,6 +9,8 @@ import (
 	metrics "github.com/rcrowley/go-metrics"
 )
 
+var ForceLeadership = false
+
 type ConsensusServiceProvider struct {
 	mySQLConsensusService ConsensusService
 	raftConsensusService  ConsensusService

--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -117,6 +117,9 @@ func (backend *MySQLBackend) IsHealthy() bool {
 }
 
 func (backend *MySQLBackend) IsLeader() bool {
+	if ForceLeadership {
+		return true
+	}
 	return atomic.LoadInt64(&backend.leaderState) > 0
 }
 

--- a/go/group/store.go
+++ b/go/group/store.go
@@ -190,6 +190,9 @@ func (store *Store) IsHealthy() bool {
 
 // IsLeader tells if this node is the current raft leader
 func (store *Store) IsLeader() bool {
+	if ForceLeadership {
+		return true
+	}
 	return store.GetState() == raft.Leader
 }
 


### PR DESCRIPTION
Followup to https://github.com/github/freno/pull/89

In this PR:

- When both MySQL and raft are configured (both `RaftDataDir` and `BackendMySQLHost` are non-empty), consensus is made by MySQL as opposed to Raft.
- Add documentation for MySQL backend