### PR TITLE
HAProxy settings: support 'Addresses', multi-address value

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -95,6 +95,7 @@ type ConfigurationSettings struct {
 	ListenPort           int
 	DataCenter           string
 	Environment          string
+	Domain               string
 	RaftBind             string
 	RaftDataDir          string
 	DefaultRaftPort      int      // if a RaftNodes entry does not specify port, use this one

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	envVariableRegexp = regexp.MustCompile("[$][{](.*)[}]")
+	envVariableRegexp = regexp.MustCompile("[$][{](.*?)[}]")
 )
 
 var instance = newConfiguration()

--- a/go/config/haproxy_config.go
+++ b/go/config/haproxy_config.go
@@ -4,21 +4,72 @@ package config
 // HAProxy-specific configuration
 //
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type HostPort struct {
+	Host string
+	Port int
+}
+
+func (h *HostPort) String() string {
+	return fmt.Sprintf("%s:%d", h.Host, h.Port)
+}
+
 type HAProxyConfigurationSettings struct {
-	Host     string
-	Port     int
-	PoolName string
+	Host      string
+	Port      int
+	Addresses string
+	PoolName  string
+}
+
+func (settings *HAProxyConfigurationSettings) parseHostPort(address string) (hostPort *HostPort, err error) {
+	tokens := strings.SplitN(address, ":", 2)
+	if len(tokens) != 2 {
+		return nil, fmt.Errorf("Cannot parse HostPort from %s. Expected format is host:port", address)
+	}
+
+	hostPort = &HostPort{Host: tokens[0]}
+	if hostPort.Port, err = strconv.Atoi(tokens[1]); err != nil {
+		return hostPort, fmt.Errorf("Invalid port: %s", tokens[1])
+	}
+
+	return hostPort, nil
+
+}
+
+func (settings *HAProxyConfigurationSettings) parseAddresses() (addresses [](*HostPort), err error) {
+	tokens := strings.Split(settings.Addresses, ",")
+	for _, token := range tokens {
+		if token = strings.TrimSpace(token); token != "" {
+			hostPort, err := settings.parseHostPort(token)
+			if err != nil {
+				return addresses, err
+			}
+			addresses = append(addresses, hostPort)
+		}
+	}
+	return addresses, err
+}
+
+func (settings *HAProxyConfigurationSettings) GetProxyAddresses() [](*HostPort) {
+	if settings.Host != "" && settings.Port > 0 {
+		h := &HostPort{Host: settings.Host, Port: settings.Port}
+		return [](*HostPort){h}
+	}
+	addresses, err := settings.parseAddresses()
+	if err != nil {
+		return [](*HostPort){}
+	}
+	return addresses
 }
 
 func (settings *HAProxyConfigurationSettings) IsEmpty() bool {
-	if settings.Host == "" {
-		return true
-	}
-	if settings.Port == 0 {
-		return true
-	}
 	if settings.PoolName == "" {
 		return true
 	}
-	return false
+	return len(settings.GetProxyAddresses()) == 0
 }

--- a/go/config/haproxy_config.go
+++ b/go/config/haproxy_config.go
@@ -88,7 +88,6 @@ func (settings *HAProxyConfigurationSettings) postReadAdjustments() error {
 		}
 		settings.Addresses = strings.Replace(settings.Addresses, envVar, envValue, -1)
 	}
-	fmt.Printf("=========== Addresses: %s\n", settings.Addresses)
 
 	return nil
 }

--- a/go/config/haproxy_config_test.go
+++ b/go/config/haproxy_config_test.go
@@ -1,0 +1,127 @@
+/*
+   Copyright 2019 GitHub Inc.
+	 See https://github.com/github/freno/blob/master/LICENSE
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/outbrain/golib/log"
+	test "github.com/outbrain/golib/tests"
+)
+
+func init() {
+	log.SetLevel(log.ERROR)
+}
+
+func TestParseAddresses(t *testing.T) {
+	{
+		c := &HAProxyConfigurationSettings{Addresses: ""}
+		addresses, err := c.parseAddresses()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(len(addresses), 0)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: ",,, , , , ,,"}
+		addresses, err := c.parseAddresses()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(len(addresses), 0)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: ",,, , , , ,localhost:1234 ,"}
+		addresses, err := c.parseAddresses()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(len(addresses), 1)
+		test.S(t).ExpectEquals(addresses[0].String(), "localhost:1234")
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: "localhost:1234,otherhost:5678"}
+		addresses, err := c.parseAddresses()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(len(addresses), 2)
+		test.S(t).ExpectEquals(addresses[0].String(), "localhost:1234")
+		test.S(t).ExpectEquals(addresses[1].String(), "otherhost:5678")
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: "localhost"}
+		_, err := c.parseAddresses()
+		test.S(t).ExpectNotNil(err)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: "localhost:"}
+		_, err := c.parseAddresses()
+		test.S(t).ExpectNotNil(err)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: "localhost:abcd"}
+		_, err := c.parseAddresses()
+		test.S(t).ExpectNotNil(err)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: "localhost:abcd:1234"}
+		_, err := c.parseAddresses()
+		test.S(t).ExpectNotNil(err)
+	}
+}
+
+func TestGetProxyAddresses(t *testing.T) {
+	{
+		c := &HAProxyConfigurationSettings{Addresses: ""}
+		addresses := c.GetProxyAddresses()
+		test.S(t).ExpectEquals(len(addresses), 0)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: ",,, , , , ,,"}
+		addresses := c.GetProxyAddresses()
+		test.S(t).ExpectEquals(len(addresses), 0)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: ",,, , , , ,localhost:1234 ,"}
+		addresses := c.GetProxyAddresses()
+		test.S(t).ExpectEquals(len(addresses), 1)
+		test.S(t).ExpectEquals(addresses[0].String(), "localhost:1234")
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: "localhost:1234,otherhost:5678"}
+		addresses := c.GetProxyAddresses()
+		test.S(t).ExpectEquals(len(addresses), 2)
+		test.S(t).ExpectEquals(addresses[0].String(), "localhost:1234")
+		test.S(t).ExpectEquals(addresses[1].String(), "otherhost:5678")
+	}
+	{
+		c := &HAProxyConfigurationSettings{Host: "explicit", Port: 1000, Addresses: "localhost:1234,otherhost:5678"}
+		addresses := c.GetProxyAddresses()
+		test.S(t).ExpectEquals(len(addresses), 1)
+		test.S(t).ExpectEquals(addresses[0].String(), "explicit:1000")
+	}
+}
+
+func TestIsEmpty(t *testing.T) {
+	{
+		c := &HAProxyConfigurationSettings{}
+		isEmpty := c.IsEmpty()
+		test.S(t).ExpectTrue(isEmpty)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Host: "localhost"}
+		isEmpty := c.IsEmpty()
+		test.S(t).ExpectTrue(isEmpty)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Host: "localhost", Port: 1234}
+		isEmpty := c.IsEmpty()
+		test.S(t).ExpectTrue(isEmpty)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Host: "localhost", Port: 1234, PoolName: "p_ro"}
+		isEmpty := c.IsEmpty()
+		test.S(t).ExpectFalse(isEmpty)
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: "localhost:1234,otherhost:5678", PoolName: "p_ro"}
+		isEmpty := c.IsEmpty()
+		test.S(t).ExpectFalse(isEmpty)
+	}
+}

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -39,6 +39,9 @@ func (settings *MySQLClusterConfigurationSettings) postReadAdjustments() error {
 	if submatch := envVariableRegexp.FindStringSubmatch(settings.Password); len(submatch) > 1 {
 		settings.Password = os.Getenv(submatch[1])
 	}
+	if err := settings.HAProxySettings.postReadAdjustments(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -67,9 +67,14 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 	if err != nil {
 		return nil, err
 	}
+	// domain := config.Settings().Domain
+	// if domain == "" {
+	// 	domain = fmt.Sprintf("%s:%s", config.Settings().DataCenter, config.Settings().Environment)
+	// }
+	domain := fmt.Sprintf("%s:%s", config.Settings().DataCenter, config.Settings().Environment)
 	backend := &MySQLBackend{
 		db:        db,
-		domain:    fmt.Sprintf("%s:%s", config.Settings().DataCenter, config.Settings().Environment),
+		domain:    domain,
 		serviceId: hostname,
 		throttler: throttler,
 	}

--- a/go/haproxy/parser.go
+++ b/go/haproxy/parser.go
@@ -20,7 +20,7 @@ var HAProxyAllUpHostsTransitioning error = fmt.Errorf("Haproxy: all host marked 
 var HAProxyAllHostsTransitioning error = fmt.Errorf("Haproxy: all hosts are in transition. HAProxy is likely reloading")
 
 var MaxHTTPGetConcurrency = 2
-var httpGetConcurrentcyChan = make(chan bool, MaxHTTPGetConcurrency)
+var httpGetConcurrencyChan = make(chan bool, MaxHTTPGetConcurrency)
 
 // parseHeader parses the HAPRoxy CSV header, which lists column names.
 // Returned is a header-to-index map
@@ -123,8 +123,8 @@ func ParseCsvHosts(csv string, poolName string) (hosts []string, err error) {
 
 // Read will read HAProxy URI and return with the CSV text
 func Read(host string, port int) (csv string, err error) {
-	httpGetConcurrentcyChan <- true
-	defer func() { <-httpGetConcurrentcyChan }()
+	httpGetConcurrencyChan <- true
+	defer func() { <-httpGetConcurrencyChan }()
 
 	haproxyUrl := fmt.Sprintf("http://%s:%d/;csv;norefresh", host, port)
 

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -254,29 +254,31 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 		go func() error {
 			throttler.mysqlClusterThresholds.Set(clusterName, clusterSettings.ThrottleThreshold, cache.DefaultExpiration)
 			if !clusterSettings.HAProxySettings.IsEmpty() {
-				log.Debugf("getting haproxy data from %s:%d", clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port)
-				csv, err := haproxy.Read(clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port)
-				if err != nil {
-					return log.Errorf("Unable to get HAproxy data from %s:%d: %+v", clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, err)
+				for _, hostPort := range clusterSettings.HAProxySettings.GetProxyAddresses() {
+					log.Debugf("getting haproxy data from %s:%d", hostPort.Host, hostPort.Port)
+					csv, err := haproxy.Read(hostPort.Host, hostPort.Port)
+					if err != nil {
+						return log.Errorf("Unable to get HAproxy data from %s:%d: %+v", hostPort.Host, hostPort, err)
+					}
+					poolName := clusterSettings.HAProxySettings.PoolName
+					hosts, err := haproxy.ParseCsvHosts(csv, poolName)
+					if err != nil {
+						return log.Errorf("Unable to get HAproxy hosts from %s:%d/#%s: %+v", hostPort.Host, hostPort.Port, poolName, err)
+					}
+					log.Debugf("Read %+v hosts from haproxy %s:%d/#%s", len(hosts), hostPort.Host, hostPort.Port, poolName)
+					clusterProbes := &mysql.ClusterProbes{
+						ClusterName:          clusterName,
+						IgnoreHostsCount:     clusterSettings.IgnoreHostsCount,
+						IgnoreHostsThreshold: clusterSettings.IgnoreHostsThreshold,
+						InstanceProbes:       mysql.NewProbes(),
+					}
+					for _, host := range hosts {
+						key := mysql.InstanceKey{Hostname: host, Port: clusterSettings.Port}
+						addInstanceKey(&key, clusterSettings, clusterProbes.InstanceProbes)
+					}
+					throttler.mysqlClusterProbesChan <- clusterProbes
+					return nil
 				}
-				poolName := clusterSettings.HAProxySettings.PoolName
-				hosts, err := haproxy.ParseCsvHosts(csv, poolName)
-				if err != nil {
-					return log.Errorf("Unable to get HAproxy hosts from %s:%d/#%s: %+v", clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, poolName, err)
-				}
-				log.Debugf("Read %+v hosts from haproxy %s:%d/#%s", len(hosts), clusterSettings.HAProxySettings.Host, clusterSettings.HAProxySettings.Port, poolName)
-				clusterProbes := &mysql.ClusterProbes{
-					ClusterName:          clusterName,
-					IgnoreHostsCount:     clusterSettings.IgnoreHostsCount,
-					IgnoreHostsThreshold: clusterSettings.IgnoreHostsThreshold,
-					InstanceProbes:       mysql.NewProbes(),
-				}
-				for _, host := range hosts {
-					key := mysql.InstanceKey{Hostname: host, Port: clusterSettings.Port}
-					addInstanceKey(&key, clusterSettings, clusterProbes.InstanceProbes)
-				}
-				throttler.mysqlClusterProbesChan <- clusterProbes
-				return nil
 			}
 
 			if !clusterSettings.VitessSettings.IsEmpty() {


### PR DESCRIPTION
HAProxy settings now support multiple HAProxy addresses.

One may either provide e.g.
```json
"HAProxySettings": {
  "Host": "10.0.0.1",
  "Port": 1010,
  "PoolName": "ro_pool"
}
```

or:
```
"HAProxySettings": {
  "Addresses": "10.0.0.1:1010,20.0.0.2:2020,30.0.0.3:3030",
  "PoolName": "ro_pool"
}
```

If multiple addresses are provided, `freno` appends the roster lists from all. It will not check for duplicates.