### PR TITLE
MySQL service ID: include port number

### DIFF
--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -72,10 +72,11 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 	// 	domain = fmt.Sprintf("%s:%s", config.Settings().DataCenter, config.Settings().Environment)
 	// }
 	domain := fmt.Sprintf("%s:%s", config.Settings().DataCenter, config.Settings().Environment)
+	serviceId := fmt.Sprintf("%s:%d", hostname, config.Settings().ListenPort)
 	backend := &MySQLBackend{
 		db:        db,
 		domain:    domain,
-		serviceId: hostname,
+		serviceId: serviceId,
 		throttler: throttler,
 	}
 	go backend.continuousElections()


### PR DESCRIPTION
The MySQL backend setup will now use `hostname:port` as the service ID, as opposed to just `hostname`.

This will be used in a future iteration where nodes in the same group could contact domain leaders using `hostname:port`.
