### PR TITLE
auto-refresh of MySQL backend throttled_apps

### DIFF
--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -306,7 +306,7 @@ func (backend *MySQLBackend) ThrottledAppsMap() (result map[string](*base.AppThr
 func (backend *MySQLBackend) UnthrottleApp(appName string) error {
 	backend.throttler.UnthrottleApp(appName)
 	query := `
-    update throttled_apps set expires_at=now() - interval 1 second where app_name=?
+    update throttled_apps set expires_at=now() where app_name=?
   `
 	args := sqlutils.Args(appName)
 	_, err := sqlutils.ExecNoPrepare(backend.db, query, args...)

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -463,10 +463,10 @@ func (throttler *Throttler) ThrottleApp(appName string, expireAt time.Time, rati
 		}
 		appThrottle = base.NewAppThrottle(expireAt, ratio)
 	}
-	if appThrottle.ExpireAt.Before(now) {
-		throttler.UnthrottleApp(appName)
-	} else {
+	if now.Before(appThrottle.ExpireAt) {
 		throttler.throttledApps.Set(appName, appThrottle, cache.DefaultExpiration)
+	} else {
+		throttler.UnthrottleApp(appName)
 	}
 }
 


### PR DESCRIPTION
When using MySQL backend, Every `10sec` reload/refresh throttled-apps based on backend table content. This is as opposed to only re-reading when becoming leader.

This is important when using share-domain functionality, where multiple independent clusters share the same data. Leader of one cluster can update the data, and leaders in other clusters need to make sure to re-read it.