### PR TITLE
share domain checks dark shipping

### DIFF
--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -168,11 +168,11 @@ func (backend *MySQLBackend) AttemptLeadership() error {
       ) values (
         ?, ?, ?, now()
       ) on duplicate key update
-			service_id = if(last_seen_active < now() - interval ? second, values(service_id), service_id),
-      share_domain = if(last_seen_active < now() - interval ? second, values(share_domain), share_domain),
+			service_id       = if(last_seen_active < now() - interval ? second, values(service_id), service_id),
+      share_domain     = if(service_id = values(service_id), values(share_domain), share_domain),
       last_seen_active = if(service_id = values(service_id), values(last_seen_active), last_seen_active)
   `
-	args := sqlutils.Args(backend.domain, backend.shareDomain, backend.serviceId, electionExpireSeconds, electionExpireSeconds)
+	args := sqlutils.Args(backend.domain, backend.shareDomain, backend.serviceId, electionExpireSeconds)
 	_, err := sqlutils.ExecNoPrepare(backend.db, query, args...)
 	return err
 }

--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -164,14 +164,15 @@ func (backend *MySQLBackend) GetStateDescription() string {
 func (backend *MySQLBackend) AttemptLeadership() error {
 	query := `
     insert ignore into service_election (
-        domain, service_id, last_seen_active
+        domain, share_domain, service_id, last_seen_active
       ) values (
-        ?, ?, now()
+        ?, ?, ?, now()
       ) on duplicate key update
-      service_id = if(last_seen_active < now() - interval ? second, values(service_id), service_id),
+			service_id = if(last_seen_active < now() - interval ? second, values(service_id), service_id),
+      share_domain = if(last_seen_active < now() - interval ? second, values(share_domain), share_domain),
       last_seen_active = if(service_id = values(service_id), values(last_seen_active), last_seen_active)
   `
-	args := sqlutils.Args(backend.domain, backend.serviceId, electionExpireSeconds)
+	args := sqlutils.Args(backend.domain, backend.shareDomain, backend.serviceId, electionExpireSeconds, electionExpireSeconds)
 	_, err := sqlutils.ExecNoPrepare(backend.db, query, args...)
 	return err
 }

--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -74,11 +74,10 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 	if err != nil {
 		return nil, err
 	}
-	// domain := config.Settings().Domain
-	// if domain == "" {
-	// 	domain = fmt.Sprintf("%s:%s", config.Settings().DataCenter, config.Settings().Environment)
-	// }
-	domain := fmt.Sprintf("%s:%s", config.Settings().DataCenter, config.Settings().Environment)
+	domain := config.Settings().Domain
+	if domain == "" {
+		domain = fmt.Sprintf("%s:%s", config.Settings().DataCenter, config.Settings().Environment)
+	}
 	shareDomain := config.Settings().ShareDomain
 	serviceId := fmt.Sprintf("%s:%d", hostname, config.Settings().ListenPort)
 	backend := &MySQLBackend{


### PR DESCRIPTION
This PR dark ships share domain checks.
A new internal check is introduced, named `freno-share-domain`. This check is the only one to actually utilize share-domain functionality, hence the only one which uses share-domain clusters health metrics when evaluating a check response.
As with any check, it generates its own metrics. We will evaluate use and future development of the functionality based on behavior of this metric (compare `freno-share-domain` with `freno`).
