### PR TITLE
MySQL polling interval set to 50ms

### DIFF
--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -25,9 +25,9 @@ import (
 )
 
 const leaderCheckInterval = 1 * time.Second
-const mysqlCollectInterval = 100 * time.Millisecond
+const mysqlCollectInterval = 50 * time.Millisecond
 const mysqlRefreshInterval = 10 * time.Second
-const mysqlAggreateInterval = 50 * time.Millisecond
+const mysqlAggreateInterval = 25 * time.Millisecond
 const mysqlHttpCheckInterval = 5 * time.Second
 const sharedDomainCollectInterval = 1 * time.Second
 


### PR DESCRIPTION
This reduces MySQL polling interval from `100ms` per MySQL host to `50ms`. Thus, `freno` will visit every MySQL server up to 20 times per sec.

Aggregation interval is similarly reduced from `50ms` to `25ms`.

This is probably as low as we will go.

cc @github/database-infrastructure 