### PR TITLE
Adding `consesus/status` API endpoint

### DIFF
--- a/go/cmd/freno/main.go
+++ b/go/cmd/freno/main.go
@@ -112,7 +112,7 @@ func httpServe() error {
 		return err
 	}
 	throttler.SetLeaderFunc(consensusServiceProvider.GetConsensusService().IsLeader)
-	throttler.SetSharedDomainServicesFuncFunc(consensusServiceProvider.GetConsensusService().GetSharedDomainServices)
+	throttler.SetSharedDomainServicesFunc(consensusServiceProvider.GetConsensusService().GetSharedDomainServices)
 
 	go consensusServiceProvider.Monitor()
 	go throttler.Operate()

--- a/go/group/consensus_service.go
+++ b/go/group/consensus_service.go
@@ -9,15 +9,16 @@ import (
 const monitorInterval = 5 * time.Second
 
 type ConsensusServiceStatus struct {
-	ServiceID               string
-	Healthy                 bool
-	IsLeader                bool
-	Leader                  string
-	State                   string
-	Domain                  string
-	ShareDomain             string
-	ShareDomainServices     map[string]string
-	ShareDomainServicesList []string // list of this service ID and share domain services, combined
+	ServiceID                 string
+	Healthy                   bool
+	IsLeader                  bool
+	Leader                    string
+	State                     string
+	Domain                    string
+	ShareDomain               string
+	ShareDomainServices       map[string]string
+	ShareDomainServicesList   []string // list of this service ID and share domain services, combined
+	HealthyDomainServicesList []string
 }
 
 // ConsensusService is a freno-oriented interface for making requests that require consensus.

--- a/go/group/consensus_service.go
+++ b/go/group/consensus_service.go
@@ -9,14 +9,15 @@ import (
 const monitorInterval = 5 * time.Second
 
 type ConsensusServiceStatus struct {
-	ServiceID           string
-	Healthy             bool
-	IsLeader            bool
-	Leader              string
-	State               string
-	Domain              string
-	ShareDomain         string
-	ShareDomainServices map[string]string
+	ServiceID               string
+	Healthy                 bool
+	IsLeader                bool
+	Leader                  string
+	State                   string
+	Domain                  string
+	ShareDomain             string
+	ShareDomainServices     map[string]string
+	ShareDomainServicesList []string // list of this service ID and share domain services, combined
 }
 
 // ConsensusService is a freno-oriented interface for making requests that require consensus.

--- a/go/group/consensus_service.go
+++ b/go/group/consensus_service.go
@@ -8,6 +8,17 @@ import (
 
 const monitorInterval = 5 * time.Second
 
+type ConsensusServiceStatus struct {
+	ServiceID           string
+	Healthy             bool
+	IsLeader            bool
+	Leader              string
+	State               string
+	Domain              string
+	ShareDomain         string
+	ShareDomainServices map[string]string
+}
+
 // ConsensusService is a freno-oriented interface for making requests that require consensus.
 type ConsensusService interface {
 	ThrottleApp(appName string, ttlMinutes int64, expireAt time.Time, ratio float64) error
@@ -19,8 +30,8 @@ type ConsensusService interface {
 	IsLeader() bool
 	GetLeader() string
 	GetStateDescription() string
-
-	GetSharedDomainServices() ([]string, error)
+	GetSharedDomainServices() (map[string]string, error)
+	GetStatus() *ConsensusServiceStatus
 
 	Monitor()
 }

--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -169,6 +169,8 @@ func (backend *MySQLBackend) GetStatus() *ConsensusServiceStatus {
 		IsLeader:            backend.IsLeader(),
 		Leader:              backend.GetLeader(),
 		State:               backend.GetStateDescription(),
+		Domain:              backend.domain,
+		ShareDomain:         backend.shareDomain,
 		ShareDomainServices: shareDomainServices,
 	}
 }

--- a/go/group/mysql.go
+++ b/go/group/mysql.go
@@ -178,16 +178,21 @@ func (backend *MySQLBackend) GetStateDescription() string {
 }
 
 func (backend *MySQLBackend) GetStatus() *ConsensusServiceStatus {
+	shareDomainServicesList := []string{backend.serviceId}
 	shareDomainServices, _ := backend.GetSharedDomainServices()
+	for _, service := range shareDomainServices {
+		shareDomainServicesList = append(shareDomainServicesList, service)
+	}
 	return &ConsensusServiceStatus{
-		ServiceID:           backend.serviceId,
-		Healthy:             backend.IsHealthy(),
-		IsLeader:            backend.IsLeader(),
-		Leader:              backend.GetLeader(),
-		State:               backend.GetStateDescription(),
-		Domain:              backend.domain,
-		ShareDomain:         backend.shareDomain,
-		ShareDomainServices: shareDomainServices,
+		ServiceID:               backend.serviceId,
+		Healthy:                 backend.IsHealthy(),
+		IsLeader:                backend.IsLeader(),
+		Leader:                  backend.GetLeader(),
+		State:                   backend.GetStateDescription(),
+		Domain:                  backend.domain,
+		ShareDomain:             backend.shareDomain,
+		ShareDomainServices:     shareDomainServices,
+		ShareDomainServicesList: shareDomainServicesList,
 	}
 }
 

--- a/go/group/store.go
+++ b/go/group/store.go
@@ -211,8 +211,20 @@ func (store *Store) GetStateDescription() string {
 	return store.GetState().String()
 }
 
-func (store *Store) GetSharedDomainServices() (services []string, err error) {
+func (store *Store) GetSharedDomainServices() (services map[string]string, err error) {
 	return services, nil
+}
+
+func (store *Store) GetStatus() *ConsensusServiceStatus {
+	shareDomainServices, _ := store.GetSharedDomainServices()
+	return &ConsensusServiceStatus{
+		ServiceID:           store.raftBind,
+		Healthy:             store.IsHealthy(),
+		IsLeader:            store.IsLeader(),
+		Leader:              store.GetLeader(),
+		State:               store.GetStateDescription(),
+		ShareDomainServices: shareDomainServices,
+	}
 }
 
 // Monitor is a utility function to routinely observe leadership state.

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -124,6 +124,7 @@ func (api *APIImpl) ConsensusState(w http.ResponseWriter, r *http.Request, _ htt
 
 // ConsensusLeader returns the consensus state of this node
 func (api *APIImpl) ConsensusStatus(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(api.consensusService.GetStatus())
 }
 

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -24,6 +24,7 @@ type API interface {
 	LeaderCheck(w http.ResponseWriter, _ *http.Request, _ httprouter.Params)
 	ConsensusLeader(w http.ResponseWriter, _ *http.Request, _ httprouter.Params)
 	ConsensusState(w http.ResponseWriter, _ *http.Request, _ httprouter.Params)
+	ConsensusStatus(w http.ResponseWriter, _ *http.Request, _ httprouter.Params)
 	Hostname(w http.ResponseWriter, _ *http.Request, _ httprouter.Params)
 	WriteCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	WriteCheckIfExists(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
@@ -119,6 +120,11 @@ func (api *APIImpl) ConsensusLeader(w http.ResponseWriter, r *http.Request, _ ht
 // ConsensusLeader returns the consensus state of this node
 func (api *APIImpl) ConsensusState(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	json.NewEncoder(w).Encode(api.consensusService.GetStateDescription())
+}
+
+// ConsensusLeader returns the consensus state of this node
+func (api *APIImpl) ConsensusStatus(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	json.NewEncoder(w).Encode(api.consensusService.GetStatus())
 }
 
 // Hostname returns the hostname this process executes on
@@ -327,6 +333,7 @@ func ConfigureRoutes(api API) *httprouter.Router {
 	register(router, "/raft/state", api.ConsensusState)
 	register(router, "/consensus/leader", api.ConsensusLeader)
 	register(router, "/consensus/state", api.ConsensusState)
+	register(router, "/consensus/status", api.ConsensusStatus)
 	register(router, "/hostname", api.Hostname)
 
 	register(router, "/check/:app/:storeType/:storeName", api.WriteCheck)

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -49,7 +49,7 @@ func init() {
 type Throttler struct {
 	isLeader                 bool
 	isLeaderFunc             func() bool
-	sharedDomainServicesFunc func() ([]string, error)
+	sharedDomainServicesFunc func() (map[string]string, error)
 
 	mysqlThrottleMetricChan chan *mysql.MySQLThrottleMetric
 	mysqlHttpCheckChan      chan *mysql.MySQLHttpCheck
@@ -109,7 +109,7 @@ func (throttler *Throttler) SetLeaderFunc(isLeaderFunc func() bool) {
 	throttler.isLeaderFunc = isLeaderFunc
 }
 
-func (throttler *Throttler) SetSharedDomainServicesFuncFunc(sharedDomainServicesFunc func() ([]string, error)) {
+func (throttler *Throttler) SetSharedDomainServicesFunc(sharedDomainServicesFunc func() (map[string]string, error)) {
 	throttler.sharedDomainServicesFunc = sharedDomainServicesFunc
 }
 


### PR DESCRIPTION
`consensus/status` returns a detailed JSON describing:

```
	ServiceID                 string
	Healthy                   bool
	IsLeader                  bool
	Leader                    string
	State                     string
	Domain                    string
	ShareDomain               string
	ShareDomainServices       map[string]string
	ShareDomainServicesList   []string
	HealthyDomainServicesList []string
```

This gives enough details for various purposes: identifying all active services within a domain, identifying which servers are collaborating on share-domain, which is healthy, which is leader etc.

A new table is created: 
```sql
CREATE TABLE service_health (
service_id varchar(128) NOT NULL,
  domain varchar(32) NOT NULL,
  share_domain varchar(32) NOT NULL,
  last_seen_active timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (service_id),
  KEY last_seen_active_idx (last_seen_active)
);
```

where servers register their liveliness, regardless of their competing for leadership. This allows us to track all known active `freno` services.

