### PR TITLE
Required: golang 1.12 or above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.12.X
+go: 1.12.x
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.9
+go: 1.12.X
 
 os:
   - linux

--- a/build.sh
+++ b/build.sh
@@ -72,8 +72,8 @@ function precheck() {
     ok=1
   fi
 
-  if [[ $(go version | egrep "go1[.][012345678]") ]]; then
-    echo "go version is too low. Must use 1.9 or above"
+  if ! go version | egrep -q 'go(1\.1[234])' ; then
+    echo "go version must be 1.12 or above"
     ok=1
   fi
 

--- a/go/base/http.go
+++ b/go/base/http.go
@@ -17,8 +17,8 @@ func SetupHttpClient(httpTimeout time.Duration) *http.Client {
 		return net.DialTimeout(network, addr, httpTimeout)
 	}
 	httpTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
-		Dial:            dialTimeout,
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: false},
+		Dial:                  dialTimeout,
 		ResponseHeaderTimeout: httpTimeout,
 	}
 	httpClient := &http.Client{Transport: httpTransport}

--- a/go/throttle/throttler.go
+++ b/go/throttle/throttler.go
@@ -290,7 +290,7 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 					log.Debugf("getting haproxy data from %s:%d", hostPort.Host, hostPort.Port)
 					csv, err := haproxy.Read(hostPort.Host, hostPort.Port)
 					if err != nil {
-						return log.Errorf("Unable to get HAproxy data from %s:%d: %+v", hostPort.Host, hostPort, err)
+						return log.Errorf("Unable to get HAproxy data from %s:%d: %+v", hostPort.Host, hostPort.Port, err)
 					}
 					if backendHosts, err := haproxy.ParseCsvHosts(csv, poolName); err == nil {
 						hosts := haproxy.FilterThrotllerHosts(backendHosts)

--- a/script/ensure-go-installed
+++ b/script/ensure-go-installed
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-PREFERRED_GO_VERSION=go1.9.2
-SUPPORTED_GO_VERSIONS='go1.[89]'
+PREFERRED_GO_VERSION=go1.12.6
+SUPPORTED_GO_VERSIONS='go1.1[234]'
 
 GO_PKG_DARWIN=${PREFERRED_GO_VERSION}.darwin-amd64.pkg
-GO_PKG_DARWIN_SHA=73fd5840d55f5566d8db6c0ffdd187577e8ebe650c783f68bd27cbf95bde6743
+GO_PKG_DARWIN_SHA=ea78245e43de2996fa0973033064b33f48820cfe39f4f3c6e953040925cc5815
 
 GO_PKG_LINUX=${PREFERRED_GO_VERSION}.linux-amd64.tar.gz
-GO_PKG_LINUX_SHA=de874549d9a8d8d8062be05808509c09a88a248e77ec14eb77453530829ac02b
+GO_PKG_LINUX_SHA=dbcf71a3c1ea53b8d54ef1b48c85a39a6c9a935d01fc8291ff2b92028e59913c
 
 export ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 cd $ROOTDIR
 
 # If Go isn't installed globally, setup environment variables for local install.
 if [ -z "$(which go)" ] || [ -z "$(go version | grep "$SUPPORTED_GO_VERSIONS")" ]; then
-  GODIR="$ROOTDIR/.vendor/go19"
+  GODIR="$ROOTDIR/.vendor/golocal"
 
   if [ $(uname -s) = "Darwin" ]; then
     export GOROOT="$GODIR/usr/local/go"
@@ -32,12 +32,12 @@ if [ -z "$(which go)" ] || [ -z "$(go version | grep "$SUPPORTED_GO_VERSIONS")" 
   cd "$GODIR";
 
   if [ $(uname -s) = "Darwin" ]; then
-    curl -L -O https://storage.googleapis.com/golang/$GO_PKG_DARWIN
+    curl -L -O https://dl.google.com/go/$GO_PKG_DARWIN
     shasum -a256 $GO_PKG_DARWIN | grep $GO_PKG_DARWIN_SHA
     xar -xf $GO_PKG_DARWIN
     cpio -i < com.googlecode.go.pkg/Payload
   else
-    curl -L -O https://storage.googleapis.com/golang/$GO_PKG_LINUX
+    curl -L -O https://dl.google.com/go/$GO_PKG_LINUX
     shasum -a256 $GO_PKG_LINUX | grep $GO_PKG_LINUX_SHA
     tar xf $GO_PKG_LINUX
   fi


### PR DESCRIPTION
Starting this PR golang1.12 is required.

Feature-wise there's nothing specific to golang1.12; however, we wish to enforce some reasonable baseline.
Also, golang1.12 introduces somewhat different formatting conventions, and since those are tested as part of CI, we will require all future code to adhere to that formatting, i.e. all local builds will require go1.12.
