### PR TITLE
Throttling based on share-domain; un-darkship functionality

### DIFF
--- a/go/throttle/check.go
+++ b/go/throttle/check.go
@@ -77,9 +77,7 @@ func (check *ThrottlerCheck) checkAppMetricResult(appName string, storeType stri
 			// low priority requests will henceforth be denied
 			go check.throttler.nonLowPriorityAppRequestsThrottled.SetDefault(metricName, true)
 		}
-	} else if appName == frenoShareDmainAppName && appName != frenoAppName && check.throttler.getShareDomainSecondsSinceHealth(metricName) >= 1 {
-		// Dark shipping the share domain functionality. Only the internal frenoShareDmainAppName uses share domain dependencies.
-
+	} else if appName != frenoAppName && check.throttler.getShareDomainSecondsSinceHealth(metricName) >= 1 {
 		// throttling based on shared domain metric.
 		// we exclude the "freno" app itself, or else this could turn into a snowball: this service ("a") seeing
 		// another service ("b") as unhealthy, itself becoming unhealthy, makind b's read into a's state as unheathly,


### PR DESCRIPTION
https://github.com/github/freno/pull/99 introduced share-domain based throttling, but dark-shipped the functionality to only apply to the share-domain internal app: https://github.com/github/freno/pull/99/files#diff-11634637460cb749624d521c95a9eaeeR79-R80

This PR brings the functionality to light. `freno` clusters sharing the same domain will cooperate such that lag in one freno cluster will cause throttling in all.