### PR TITLE
HAProxyConfigurationSettings.Addresses may contain full URLs

### DIFF
--- a/go/config/haproxy_config_test.go
+++ b/go/config/haproxy_config_test.go
@@ -45,6 +45,22 @@ func TestParseAddresses(t *testing.T) {
 		test.S(t).ExpectEquals(addresses[1].String(), "http://otherhost:5678")
 	}
 	{
+		c := &HAProxyConfigurationSettings{Addresses: "localhost:1234,http://otherhost:5679"}
+		addresses, err := c.parseAddresses()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(len(addresses), 2)
+		test.S(t).ExpectEquals(addresses[0].String(), "http://localhost:1234")
+		test.S(t).ExpectEquals(addresses[1].String(), "http://otherhost:5679")
+	}
+	{
+		c := &HAProxyConfigurationSettings{Addresses: "localhost:1234,https://otherhost:5679"}
+		addresses, err := c.parseAddresses()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(len(addresses), 2)
+		test.S(t).ExpectEquals(addresses[0].String(), "http://localhost:1234")
+		test.S(t).ExpectEquals(addresses[1].String(), "https://otherhost:5679")
+	}
+	{
 		c := &HAProxyConfigurationSettings{Addresses: "localhost"}
 		_, err := c.parseAddresses()
 		test.S(t).ExpectNotNil(err)

--- a/go/config/haproxy_config_test.go
+++ b/go/config/haproxy_config_test.go
@@ -34,15 +34,15 @@ func TestParseAddresses(t *testing.T) {
 		addresses, err := c.parseAddresses()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(len(addresses), 1)
-		test.S(t).ExpectEquals(addresses[0].String(), "localhost:1234")
+		test.S(t).ExpectEquals(addresses[0].String(), "http://localhost:1234")
 	}
 	{
 		c := &HAProxyConfigurationSettings{Addresses: "localhost:1234,otherhost:5678"}
 		addresses, err := c.parseAddresses()
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(len(addresses), 2)
-		test.S(t).ExpectEquals(addresses[0].String(), "localhost:1234")
-		test.S(t).ExpectEquals(addresses[1].String(), "otherhost:5678")
+		test.S(t).ExpectEquals(addresses[0].String(), "http://localhost:1234")
+		test.S(t).ExpectEquals(addresses[1].String(), "http://otherhost:5678")
 	}
 	{
 		c := &HAProxyConfigurationSettings{Addresses: "localhost"}
@@ -69,32 +69,37 @@ func TestParseAddresses(t *testing.T) {
 func TestGetProxyAddresses(t *testing.T) {
 	{
 		c := &HAProxyConfigurationSettings{Addresses: ""}
-		addresses := c.GetProxyAddresses()
+		addresses, err := c.GetProxyAddresses()
+		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(len(addresses), 0)
 	}
 	{
 		c := &HAProxyConfigurationSettings{Addresses: ",,, , , , ,,"}
-		addresses := c.GetProxyAddresses()
+		addresses, err := c.GetProxyAddresses()
+		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(len(addresses), 0)
 	}
 	{
 		c := &HAProxyConfigurationSettings{Addresses: ",,, , , , ,localhost:1234 ,"}
-		addresses := c.GetProxyAddresses()
+		addresses, err := c.GetProxyAddresses()
+		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(len(addresses), 1)
-		test.S(t).ExpectEquals(addresses[0].String(), "localhost:1234")
+		test.S(t).ExpectEquals(addresses[0].String(), "http://localhost:1234")
 	}
 	{
 		c := &HAProxyConfigurationSettings{Addresses: "localhost:1234,otherhost:5678"}
-		addresses := c.GetProxyAddresses()
+		addresses, err := c.GetProxyAddresses()
+		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(len(addresses), 2)
-		test.S(t).ExpectEquals(addresses[0].String(), "localhost:1234")
-		test.S(t).ExpectEquals(addresses[1].String(), "otherhost:5678")
+		test.S(t).ExpectEquals(addresses[0].String(), "http://localhost:1234")
+		test.S(t).ExpectEquals(addresses[1].String(), "http://otherhost:5678")
 	}
 	{
 		c := &HAProxyConfigurationSettings{Host: "explicit", Port: 1000, Addresses: "localhost:1234,otherhost:5678"}
-		addresses := c.GetProxyAddresses()
+		addresses, err := c.GetProxyAddresses()
+		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(len(addresses), 1)
-		test.S(t).ExpectEquals(addresses[0].String(), "explicit:1000")
+		test.S(t).ExpectEquals(addresses[0].String(), "http://explicit:1000")
 	}
 }
 

--- a/go/config/haproxy_config_test.go
+++ b/go/config/haproxy_config_test.go
@@ -61,6 +61,14 @@ func TestParseAddresses(t *testing.T) {
 		test.S(t).ExpectEquals(addresses[1].String(), "https://otherhost:5679")
 	}
 	{
+		c := &HAProxyConfigurationSettings{Addresses: "http://localhost:1234/stats/pool/,https://otherhost:5679"}
+		addresses, err := c.parseAddresses()
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(len(addresses), 2)
+		test.S(t).ExpectEquals(addresses[0].String(), "http://localhost:1234/stats/pool/")
+		test.S(t).ExpectEquals(addresses[1].String(), "https://otherhost:5679")
+	}
+	{
 		c := &HAProxyConfigurationSettings{Addresses: "localhost"}
 		_, err := c.parseAddresses()
 		test.S(t).ExpectNotNil(err)

--- a/go/haproxy/parser.go
+++ b/go/haproxy/parser.go
@@ -129,12 +129,17 @@ func ParseCsvHosts(csv string, poolName string) (backendHosts [](*BackendHost), 
 	return ParseHosts(csvLines, poolName)
 }
 
+func toCSVUrl(u url.URL) *url.URL {
+	u.Path = fmt.Sprintf("%s;csv;norefresh", u.Path)
+	return &u
+}
+
 // Read will read HAProxy URI and return with the CSV text
 func Read(u *url.URL) (csv string, err error) {
 	httpGetConcurrencyChan <- true
 	defer func() { <-httpGetConcurrencyChan }()
 
-	haproxyUrl := fmt.Sprintf("%s;csv;norefresh", u.String())
+	haproxyUrl := toCSVUrl(*u).String()
 
 	if cachedCSV, found := csvCache.Get(haproxyUrl); found {
 		return cachedCSV.(string), nil

--- a/go/haproxy/parser.go
+++ b/go/haproxy/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -129,11 +130,11 @@ func ParseCsvHosts(csv string, poolName string) (backendHosts [](*BackendHost), 
 }
 
 // Read will read HAProxy URI and return with the CSV text
-func Read(host string, port int) (csv string, err error) {
+func Read(u *url.URL) (csv string, err error) {
 	httpGetConcurrencyChan <- true
 	defer func() { <-httpGetConcurrencyChan }()
 
-	haproxyUrl := fmt.Sprintf("http://%s:%d/;csv;norefresh", host, port)
+	haproxyUrl := fmt.Sprintf("%s;csv;norefresh", u.String())
 
 	if cachedCSV, found := csvCache.Get(haproxyUrl); found {
 		return cachedCSV.(string), nil

--- a/go/haproxy/parser_test.go
+++ b/go/haproxy/parser_test.go
@@ -6,6 +6,7 @@
 package haproxy
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -79,6 +80,27 @@ statsctl,BACKEND,0,0,0,0,200,0,2788357,173364223,0,0,,0,0,0,0,UP,0,0,0,,0,103206
 
 func init() {
 	log.SetLevel(log.ERROR)
+}
+
+func TestToCsvUrl(t *testing.T) {
+	{
+		u, err := url.Parse("http://10.0.0.2:1234")
+		test.S(t).ExpectNil(err)
+		csvUrl := toCSVUrl(*u)
+		test.S(t).ExpectEquals(csvUrl.String(), "http://10.0.0.2:1234/;csv;norefresh")
+	}
+	{
+		u, err := url.Parse("http://10.0.0.2:1234/")
+		test.S(t).ExpectNil(err)
+		csvUrl := toCSVUrl(*u)
+		test.S(t).ExpectEquals(csvUrl.String(), "http://10.0.0.2:1234/;csv;norefresh")
+	}
+	{
+		u, err := url.Parse("http://10.0.0.2:1234/stats/pool")
+		test.S(t).ExpectNil(err)
+		csvUrl := toCSVUrl(*u)
+		test.S(t).ExpectEquals(csvUrl.String(), "http://10.0.0.2:1234/stats/pool;csv;norefresh")
+	}
 }
 
 func TestParseHeader(t *testing.T) {


### PR DESCRIPTION
Up till now, `HAProxyConfigurationSettings.Addresses` could only contains `host:port[,host:port...]`

From now on, it may contain full blown URLs; for example, the following is valid:

```json
   "Addresses": "https://some.host.name:1234/stats/pool/,10.0.0.2:1234"
```

In the above, `10.0.0.2:1234` is implicitly assumed to mean `http://10.0.0.2:1234`, and `https://some.host.name:1234/stats/pool/` is accepted and used "as-is".
