### PR TITLE
Api to ignore hosts

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -81,6 +81,27 @@ func (config *Configuration) Read(fileNames ...string) error {
 	return nil
 }
 
+func (config *Configuration) Save() error {
+	fileName := config.readFileNames[len(config.readFileNames)-1]
+	file, err := os.OpenFile(fileName, os.O_WRONLY, 0644)
+	if err != nil {
+		return log.Errorf("Cannot read config file %s, error was: %s", fileName, err)
+	}
+	defer file.Close()
+
+	enconder, err := json.Marshal(config.settings)
+	if err != nil {
+		return err
+	}
+	_, err = file.Write(enconder)
+	if err == nil {
+		log.Infof("Config save from %s", fileName)
+	} else {
+		return fmt.Errorf("Cannot write config file %s, error was: %s", fileName, err)
+	}
+	return nil
+}
+
 // Reload re-reads configuration from last used files
 func (config *Configuration) Reload() error {
 	return config.Read(config.readFileNames...)

--- a/go/config/mysql_config.go
+++ b/go/config/mysql_config.go
@@ -117,3 +117,23 @@ func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
 	}
 	return nil
 }
+
+func (settings *MySQLConfigurationSettings) AddIgnoreHost(hostName string) {
+	for _, ignoredHost := range settings.IgnoreHosts {
+        if ignoredHost == hostName {
+			return
+		}
+    }
+    settings.IgnoreHosts = append(settings.IgnoreHosts, hostName)
+}
+
+func (settings *MySQLConfigurationSettings) RemoveIgnoreHost(hostName string) {
+	newIngoredHosts := []string{}
+	for _, ignoredHost := range settings.IgnoreHosts {
+        if ignoredHost == hostName {
+			continue
+		}
+		newIngoredHosts = append(newIngoredHosts, ignoredHost)
+    }
+	settings.IgnoreHosts = newIngoredHosts
+}


### PR DESCRIPTION
This PR adds 3 news API routes:
- `/skip-host/<hostname>` Adds host to MySQL ignore host list
- `/recover-host/<hostname>` Remove host from MySQL ignore host list
- `/skipped-hosts` List all hosts in MySQL ignore host list

Working on tests...

Closes: #28 