### PR TITLE
Add TLS options for http server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin/
 main
 conf/freno.local.conf.json
 .vendor/
+server.crt
+server.key

--- a/conf/freno.conf.ssl.json
+++ b/conf/freno.conf.ssl.json
@@ -1,0 +1,9 @@
+{
+  "ListenPort": 8088,
+  "RaftBind": "127.0.0.1:10008",
+  "RaftDataDir": "/tmp",
+  "RaftNodes": [],
+  "UseSSL": true,
+  "SSLPrivateKeyFile": "server.key",
+  "SSLCertFile": "server.crt"
+}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -109,6 +109,10 @@ type ConfigurationSettings struct {
 	MemcacheServers      []string // if given, freno will report to aggregated values to given memcache
 	MemcachePath         string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
 	Stores               StoresSettings
+	UseSSL               bool
+	SSLCertFile          string
+	SSLPrivateKeyFile    string
+	SSLSkipVerify        bool
 }
 
 func newConfigurationSettings() *ConfigurationSettings {


### PR DESCRIPTION
This is a first attempt at adding TLS options to freno.

I've looked at the way SSL is initialized in Orchestrator here https://github.com/github/orchestrator/blob/master/go/app/http.go#L149-L161 and tried to follow that example but also do a bit of simplification as well.

I've added a second sample config file in `conf` to enable the tls options for testing so you can invoke freno with: `./freno -http -config conf/freno.conf.ssl.json -verbose`

That also requires some self-signed certificates to be generated which is straight forward with:
```
openssl req -x509 -nodes -newkey rsa:2048 -keyout server.rsa.key -out server.rsa.crt -days 3650
ln -sf server.rsa.key server.key
ln -sf server.rsa.crt server.crt
```

There are a few questions I had about this change.
1. I didn't include an option to set a certificate authority as part of the configuration -- what's the use case in Orchestrator and do you think it's necessary to include that option here?
2. The code in Orchestrator takes some extra manual steps to load, parse and verify some of the certificate files, but I don't see many examples of other TLS configuration setups that take these extra steps.  Are they needed here?

Also I think this PR isn't complete until it has additional documentation to explain how to configure the server for SSL operation as well.

/cc @shlomi-noach 
/cc https://github.com/github/freno/issues/112