### PR TITLE
Fix HAProxy address parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 main
 conf/freno.local.conf.json
 .vendor/
+.idea/

--- a/go/config/haproxy_config.go
+++ b/go/config/haproxy_config.go
@@ -28,6 +28,10 @@ func (h *HostPort) URL() *url.URL {
 
 func ParseHostPort(address string) (hostPort *HostPort, err error) {
 	if !strings.Contains(address, ":") {
+		if address == "" {
+			return &HostPort{address, 80}, fmt.Errorf("Invalid host address: %s", address)
+		}
+
 		return &HostPort{Host: address, Port: 80}, nil
 	}
 

--- a/go/config/haproxy_config.go
+++ b/go/config/haproxy_config.go
@@ -27,6 +27,10 @@ func (h *HostPort) URL() *url.URL {
 }
 
 func ParseHostPort(address string) (hostPort *HostPort, err error) {
+	if !strings.Contains(address, ":") {
+		return &HostPort{Host: address, Port: 80}, nil
+	}
+
 	tokens := strings.SplitN(address, ":", 2)
 	if len(tokens) != 2 {
 		return nil, fmt.Errorf("Cannot parse HostPort from %s. Expected format is host:port", address)

--- a/go/config/haproxy_config_test.go
+++ b/go/config/haproxy_config_test.go
@@ -71,7 +71,7 @@ func TestParseAddresses(t *testing.T) {
 	{
 		c := &HAProxyConfigurationSettings{Addresses: "localhost"}
 		_, err := c.parseAddresses()
-		test.S(t).ExpectNotNil(err)
+		test.S(t).ExpectNil(err)
 	}
 	{
 		c := &HAProxyConfigurationSettings{Addresses: "localhost:"}


### PR DESCRIPTION
This PR fixes the HAProxy address parse to correctly handle addresses without an explicit port:
Example: `http://123.123.123.123/haproxy_stats/` 