### PR TITLE
Gather REPLICA tablet types from Vitess only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,5 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563
 	golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed // indirect
+	vitess.io/vitess v2.1.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
@@ -45,6 +46,9 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed h1:uPxWBzB3+mlnjy9W58qY1j/cjyFjutgw/Vhan2zLy/A=
 golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+vitess.io/vitess v2.1.1+incompatible h1:nuuGHiWYWpudD3gOCLeGzol2EJ25e/u5Wer2wV1O130=
+vitess.io/vitess v2.1.1+incompatible/go.mod h1:h4qvkyNYTOC0xI+vcidSWoka0gQAZc9ZPHbkHo48gP0=

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -327,13 +327,14 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 				if err != nil {
 					return log.Errorf("Unable to get vitess hosts from %s, %s/%s: %+v", clusterSettings.VitessSettings.API, keyspace, shard, err)
 				}
-				log.Debugf("Read %+v hosts from vitess %s, %s/%s", len(tablets), clusterSettings.VitessSettings.API, keyspace, shard)
+				replicas := vitess.FilterReplicaTablets(tablets)
+				log.Debugf("Read %+v replica hosts from vitess %s, %s/%s", len(replicas), clusterSettings.VitessSettings.API, keyspace, shard)
 				clusterProbes := &mysql.ClusterProbes{
 					ClusterName:      clusterName,
 					IgnoreHostsCount: clusterSettings.IgnoreHostsCount,
 					InstanceProbes:   mysql.NewProbes(),
 				}
-				for _, tablet := range tablets {
+				for _, tablet := range replicas {
 					key := mysql.InstanceKey{Hostname: tablet.MysqlHostname, Port: int(tablet.MysqlPort)}
 					addInstanceKey(&key, clusterName, clusterSettings, clusterProbes.InstanceProbes)
 				}

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -327,14 +327,13 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 				if err != nil {
 					return log.Errorf("Unable to get vitess hosts from %s, %s/%s: %+v", clusterSettings.VitessSettings.API, keyspace, shard, err)
 				}
-				replicas := vitess.FilterReplicaTablets(tablets)
-				log.Debugf("Read %+v replica hosts from vitess %s, %s/%s", len(replicas), clusterSettings.VitessSettings.API, keyspace, shard)
+				log.Debugf("Read %+v hosts from vitess %s, %s/%s", len(tablets), clusterSettings.VitessSettings.API, keyspace, shard)
 				clusterProbes := &mysql.ClusterProbes{
 					ClusterName:      clusterName,
 					IgnoreHostsCount: clusterSettings.IgnoreHostsCount,
 					InstanceProbes:   mysql.NewProbes(),
 				}
-				for _, tablet := range replicas {
+				for _, tablet := range tablets {
 					key := mysql.InstanceKey{Hostname: tablet.MysqlHostname, Port: int(tablet.MysqlPort)}
 					addInstanceKey(&key, clusterName, clusterSettings, clusterProbes.InstanceProbes)
 				}

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -18,8 +18,8 @@ type Tablet struct {
 	Type          topodata.TabletType `json:"type,omitempty"`
 }
 
-// isReplica returns a bool reflecting if a tablet type is REPLICA
-func (t Tablet) isReplica() bool {
+// IsValidReplica returns a bool reflecting if a tablet type is REPLICA
+func (t Tablet) IsValidReplica() bool {
 	return t.Type == topodata.TabletType_REPLICA
 }
 
@@ -40,7 +40,7 @@ func constructAPIURL(api string, keyspace string, shard string) (url string) {
 // filterReplicaTablets parses a list of tablets, returning replica tablets only
 func filterReplicaTablets(tablets []Tablet) (replicas []Tablet) {
 	for _, tablet := range tablets {
-		if tablet.isReplica() {
+		if tablet.IsValidReplica() {
 			replicas = append(replicas, tablet)
 		}
 	}
@@ -48,7 +48,7 @@ func filterReplicaTablets(tablets []Tablet) (replicas []Tablet) {
 }
 
 // ParseTablets reads from vitess /api/ks_tablets/<keyspace>/[shard] and returns a
-// listing (mysql_hostname, mysql_port) of REPLICA tablets
+// listing (mysql_hostname, mysql_port, type) of REPLICA tablets
 func ParseTablets(api string, keyspace string, shard string) (tablets []Tablet, err error) {
 	url := constructAPIURL(api, keyspace, shard)
 	resp, err := httpClient.Get(url)

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -48,7 +48,7 @@ func filterReplicaTablets(tablets []Tablet) (replicas []Tablet) {
 }
 
 // ParseTablets reads from vitess /api/ks_tablets/<keyspace>/[shard] and returns a
-// tablet (mysql_hostname, mysql_port) listing
+// listing (mysql_hostname, mysql_port) of REPLICA tablets
 func ParseTablets(api string, keyspace string, shard string) (tablets []Tablet, err error) {
 	url := constructAPIURL(api, keyspace, shard)
 	resp, err := httpClient.Get(url)

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -37,6 +37,16 @@ func constructAPIURL(api string, keyspace string, shard string) (url string) {
 	return url
 }
 
+// filterReplicaTablets parses a list of tablets, returning replica tablets only
+func filterReplicaTablets(tablets []Tablet) (replicas []Tablet) {
+	for _, tablet := range tablets {
+		if tablet.isReplica() {
+			replicas = append(replicas, tablet)
+		}
+	}
+	return replicas
+}
+
 // ParseTablets reads from vitess /api/ks_tablets/<keyspace>/[shard] and returns a
 // tablet (mysql_hostname, mysql_port) listing
 func ParseTablets(api string, keyspace string, shard string) (tablets []Tablet, err error) {
@@ -53,15 +63,5 @@ func ParseTablets(api string, keyspace string, shard string) (tablets []Tablet, 
 	}
 
 	err = json.Unmarshal(body, &tablets)
-	return tablets, err
-}
-
-// FilterReplicaTablets parses a list of tablets, returning replica tablets only
-func FilterReplicaTablets(tablets []Tablet) (replicas []Tablet) {
-	for _, tablet := range tablets {
-		if tablet.isReplica() {
-			replicas = append(replicas, tablet)
-		}
-	}
-	return replicas
+	return filterReplicaTablets(tablets), err
 }

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -18,8 +18,8 @@ type Tablet struct {
 	Type          topodata.TabletType `json:"type,omitempty"`
 }
 
-// IsReplica returns a bool reflecting if a tablet type is REPLICA
-func (t Tablet) IsReplica() bool {
+// isReplica returns a bool reflecting if a tablet type is REPLICA
+func (t Tablet) isReplica() bool {
 	return t.Type == topodata.TabletType_REPLICA
 }
 
@@ -60,7 +60,7 @@ func ParseTablets(api string, keyspace string, shard string) (tablets []Tablet, 
 func FilterReplicaTablets(tablets []Tablet) []Tablet {
 	replicas := make([]Tablet, 0)
 	for _, tablet := range tablets {
-		if tablet.IsReplica() {
+		if tablet.isReplica() {
 			replicas = append(replicas, tablet)
 		}
 	}

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -57,8 +57,7 @@ func ParseTablets(api string, keyspace string, shard string) (tablets []Tablet, 
 }
 
 // FilterReplicaTablets parses a list of tablets, returning replica tablets only
-func FilterReplicaTablets(tablets []Tablet) []Tablet {
-	replicas := make([]Tablet, 0)
+func FilterReplicaTablets(tablets []Tablet) (replicas []Tablet) {
 	for _, tablet := range tablets {
 		if tablet.isReplica() {
 			replicas = append(replicas, tablet)

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -18,6 +18,11 @@ type Tablet struct {
 	Type          topodata.TabletType `json:"type,omitempty"`
 }
 
+// IsReplica returns a bool reflecting if a tablet type is REPLICA
+func (t Tablet) IsReplica() bool {
+	return t.Type == topodata.TabletType_REPLICA
+}
+
 var httpClient = http.Client{
 	Timeout: 1 * time.Second,
 }
@@ -51,15 +56,11 @@ func ParseTablets(api string, keyspace string, shard string) (tablets []Tablet, 
 	return tablets, err
 }
 
-func isReplicaTablet(tablet Tablet) bool {
-	return tablet.Type == topodata.TabletType_REPLICA
-}
-
 // FilterReplicaTablets parses a list of tablets, returning replica tablets only
 func FilterReplicaTablets(tablets []Tablet) []Tablet {
 	replicas := make([]Tablet, 0)
 	for _, tablet := range tablets {
-		if isReplicaTablet(tablet) {
+		if tablet.IsReplica() {
 			replicas = append(replicas, tablet)
 		}
 	}

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -1,0 +1,35 @@
+package vitess
+
+import (
+	"testing"
+
+	"vitess.io/vitess/go/vt/proto/topodata"
+)
+
+func TestFilterReplicaTablets(t *testing.T) {
+	replicas := FilterReplicaTablets([]Tablet{
+		{
+			MysqlHostname: t.Name() + "1",
+			Type:          topodata.TabletType_MASTER,
+		},
+		{
+			MysqlHostname: t.Name() + "2", // this node is valid
+			Type:          topodata.TabletType_REPLICA,
+		},
+		{
+			MysqlHostname: t.Name() + "3",
+			Type:          topodata.TabletType_BACKUP,
+		},
+		{
+
+			MysqlHostname: t.Name() + "4",
+			Type:          topodata.TabletType_RESTORE,
+		},
+	})
+	if len(replicas) != 1 {
+		t.Fatalf("Expected 1 replica, got %v", replicas)
+	}
+	if replicas[0].MysqlHostname != t.Name()+"2" {
+		t.Fatalf("Expected hostname %q, got %q", t.Name()+"2", replicas[0].MysqlHostname)
+	}
+}

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -49,17 +49,6 @@ func TestParseTablets(t *testing.T) {
 	}))
 	defer vitessApi.Close()
 
-	t.Run("not-found", func(t *testing.T) {
-		tablets, err := ParseTablets(vitessApi.URL, "not-found", "00")
-		if err != nil {
-			t.Fatalf("Expected no error, got %q", err)
-		}
-
-		if len(tablets) > 0 {
-			t.Fatalf("Expected 0 tablets, got %d", len(tablets))
-		}
-	})
-
 	t.Run("success", func(t *testing.T) {
 		tablets, err := ParseTablets(vitessApi.URL, "test", "00")
 		if err != nil {
@@ -72,6 +61,25 @@ func TestParseTablets(t *testing.T) {
 
 		if tablets[0].MysqlHostname != "replica" {
 			t.Fatalf("Expected hostname %q, got %q", "replica", tablets[0].MysqlHostname)
+		}
+	})
+
+	t.Run("not-found", func(t *testing.T) {
+		tablets, err := ParseTablets(vitessApi.URL, "not-found", "00")
+		if err != nil {
+			t.Fatalf("Expected no error, got %q", err)
+		}
+
+		if len(tablets) > 0 {
+			t.Fatalf("Expected 0 tablets, got %d", len(tablets))
+		}
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		vitessApi.Close() // kill the mock vitess API
+		_, err := ParseTablets(vitessApi.URL, "fail", "00")
+		if err == nil {
+			t.Fatal("Expected error, got nil")
 		}
 	})
 }

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -1,39 +1,77 @@
 package vitess
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"vitess.io/vitess/go/vt/proto/topodata"
 )
 
-func TestFilterReplicaTablets(t *testing.T) {
-	replicas := filterReplicaTablets([]Tablet{
-		{
-			MysqlHostname: t.Name() + "1",
-			Type:          topodata.TabletType_MASTER,
-		},
-		{
-			MysqlHostname: t.Name() + "2", // this node is valid
-			Type:          topodata.TabletType_REPLICA,
-		},
-		{
-			MysqlHostname: t.Name() + "3",
-			Type:          topodata.TabletType_SPARE,
-		},
-		{
-			MysqlHostname: t.Name() + "4",
-			Type:          topodata.TabletType_BACKUP,
-		},
-		{
+func TestParseTablets(t *testing.T) {
+	vitessApi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/api/keyspace/test/tablets/00":
+			data, _ := json.Marshal([]Tablet{
+				{
+					MysqlHostname: "master",
+					Type:          topodata.TabletType_MASTER,
+				},
+				{
+					MysqlHostname: "replica",
+					Type:          topodata.TabletType_REPLICA,
+				},
+				{
+					MysqlHostname: "spare",
+					Type:          topodata.TabletType_SPARE,
+				},
+				{
+					MysqlHostname: "batch",
+					Type:          topodata.TabletType_BATCH,
+				},
+				{
+					MysqlHostname: "backup",
+					Type:          topodata.TabletType_BACKUP,
+				},
+				{
 
-			MysqlHostname: t.Name() + "5",
-			Type:          topodata.TabletType_RESTORE,
-		},
+					MysqlHostname: "restore",
+					Type:          topodata.TabletType_RESTORE,
+				},
+			})
+			fmt.Fprint(w, string(data))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, "[]")
+		}
+	}))
+	defer vitessApi.Close()
+
+	t.Run("not-found", func(t *testing.T) {
+		tablets, err := ParseTablets(vitessApi.URL, "not-found", "00")
+		if err != nil {
+			t.Fatalf("Expected no error, got %q", err)
+		}
+
+		if len(tablets) > 0 {
+			t.Fatalf("Expected 0 tablets, got %d", len(tablets))
+		}
 	})
-	if len(replicas) != 1 {
-		t.Fatalf("Expected 1 replica, got %v", replicas)
-	}
-	if replicas[0].MysqlHostname != t.Name()+"2" {
-		t.Fatalf("Expected hostname %q, got %q", t.Name()+"2", replicas[0].MysqlHostname)
-	}
+
+	t.Run("success", func(t *testing.T) {
+		tablets, err := ParseTablets(vitessApi.URL, "test", "00")
+		if err != nil {
+			t.Fatalf("Expected no error, got %q", err)
+		}
+
+		if len(tablets) != 1 {
+			t.Fatalf("Expected 1 tablet, got %d", len(tablets))
+		}
+
+		if tablets[0].MysqlHostname != "replica" {
+			t.Fatalf("Expected hostname %q, got %q", "replica", tablets[0].MysqlHostname)
+		}
+	})
 }

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -18,11 +18,15 @@ func TestFilterReplicaTablets(t *testing.T) {
 		},
 		{
 			MysqlHostname: t.Name() + "3",
+			Type:          topodata.TabletType_SPARE,
+		},
+		{
+			MysqlHostname: t.Name() + "4",
 			Type:          topodata.TabletType_BACKUP,
 		},
 		{
 
-			MysqlHostname: t.Name() + "4",
+			MysqlHostname: t.Name() + "5",
 			Type:          topodata.TabletType_RESTORE,
 		},
 	})

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestFilterReplicaTablets(t *testing.T) {
-	replicas := FilterReplicaTablets([]Tablet{
+	replicas := filterReplicaTablets([]Tablet{
 		{
 			MysqlHostname: t.Name() + "1",
 			Type:          topodata.TabletType_MASTER,


### PR DESCRIPTION
This PR updates the Vitesssupport to only consider `REPLICA` tablet types for probing

Today this logic gathers any host available, including nodes that probably shouldn't get checked like `MASTER`, `DRAINED`, `SPARE`, `BACKUP`, `RESTORE`, etc. It can be valid for non-`REPLICA`s to have lag

The full list of tablet types available is here: https://godoc.org/vitess.io/vitess/go/vt/proto/topodata#TabletType

The `REPLICA` tablet-type is described as:
> REPLICA is a slave type. It is used to serve live traffic. A REPLICA can be promoted to MASTER. A demoted MASTER will go to REPLICA.

EDIT: `go mod` is pulling in a v.2.1.1 version of the Vitess package I used, due to this issue here: https://github.com/vitessio/vitess/issues/5019. I only use 1 x API struct so I think it's ok