### PR TITLE
Update vitess http client timeout to five seconds

### DIFF
--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -24,7 +24,7 @@ func (t Tablet) IsValidReplica() bool {
 }
 
 var httpClient = http.Client{
-	Timeout: 1 * time.Second,
+	Timeout: 5 * time.Second,
 }
 
 func constructAPIURL(api string, keyspace string, shard string) (url string) {


### PR DESCRIPTION
This PR updates the http timeout for making vitess API calls from 1 second to 5 seconds to allow for longer response times to gather vitess tablet information.

