### PR TITLE
Add Dockerfile for building in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.14-alpine
+
+COPY . /go/src/github.com/github/freno
+WORKDIR /go/src/github.com/github/freno
+
+RUN go build -ldflags '-w -s' -o freno cmd/freno/main.go
+
+FROM alpine
+
+COPY --from=0 /go/src/github.com/github/freno/freno /usr/local/bin/freno
+
+USER nobody
+ENTRYPOINT ["freno"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ RUN go build -ldflags '-w -s' -o freno cmd/freno/main.go
 FROM alpine
 
 COPY --from=0 /go/src/github.com/github/freno/freno /usr/local/bin/freno
+COPY conf/freno.conf.json /etc/freno.conf.json
 
-USER nobody
+RUN adduser --system freno
+RUN mkdir -p /var/lib/freno && chown -R freno /var/lib/freno
+
+USER freno
 ENTRYPOINT ["freno"]
+CMD ["--http"]


### PR DESCRIPTION
This PR adds a Dockerfile that creates a Docker image of Freno

Alpine linux and a 2-stage build is used to make the image very small (< 20mb)