### PR TITLE
Support polling specific Vitess cells

### DIFF
--- a/pkg/config/mysql_config.go
+++ b/pkg/config/mysql_config.go
@@ -58,7 +58,7 @@ type MySQLConfigurationSettings struct {
 	HttpCheckPort        int      // port for HTTP check. -1 to disable.
 	HttpCheckPath        string   // If non-empty, requires HttpCheckPort
 	IgnoreHosts          []string // If non empty, substrings to indicate hosts to be ignored/skipped
-	VitessCell           string   // Name of the Vitess cell for polling tablet hosts
+	VitessCells          []string // Name of the Vitess cells for polling tablet hosts
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }
@@ -115,8 +115,8 @@ func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
 		if len(clusterSettings.IgnoreHosts) == 0 {
 			clusterSettings.IgnoreHosts = settings.IgnoreHosts
 		}
-		if !clusterSettings.VitessSettings.IsEmpty() && clusterSettings.VitessSettings.Cell == "" {
-			clusterSettings.VitessSettings.Cell = settings.VitessCell
+		if !clusterSettings.VitessSettings.IsEmpty() && len(clusterSettings.VitessSettings.Cells) < 1 {
+			clusterSettings.VitessSettings.Cells = settings.VitessCells
 		}
 	}
 	return nil

--- a/pkg/config/mysql_config.go
+++ b/pkg/config/mysql_config.go
@@ -58,6 +58,7 @@ type MySQLConfigurationSettings struct {
 	HttpCheckPort        int      // port for HTTP check. -1 to disable.
 	HttpCheckPath        string   // If non-empty, requires HttpCheckPort
 	IgnoreHosts          []string // If non empty, substrings to indicate hosts to be ignored/skipped
+	VitessCell           string   // Name of the Vitess cell for polling tablet hosts
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }
@@ -113,6 +114,9 @@ func (settings *MySQLConfigurationSettings) postReadAdjustments() error {
 		}
 		if len(clusterSettings.IgnoreHosts) == 0 {
 			clusterSettings.IgnoreHosts = settings.IgnoreHosts
+		}
+		if !clusterSettings.VitessSettings.IsEmpty() && clusterSettings.VitessSettings.Cell == "" {
+			clusterSettings.VitessSettings.Cell = settings.VitessCell
 		}
 	}
 	return nil

--- a/pkg/config/vitess_config.go
+++ b/pkg/config/vitess_config.go
@@ -6,7 +6,7 @@ package config
 
 type VitessConfigurationSettings struct {
 	API         string
-	Cell        string
+	Cells       []string
 	Keyspace    string
 	Shard       string
 	TimeoutSecs uint

--- a/pkg/config/vitess_config.go
+++ b/pkg/config/vitess_config.go
@@ -6,6 +6,7 @@ package config
 
 type VitessConfigurationSettings struct {
 	API         string
+	Cell        string
 	Keyspace    string
 	Shard       string
 	TimeoutSecs uint

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -327,7 +327,9 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 				if err != nil {
 					return log.Errorf("Unable to get vitess hosts from %s, %s/%s: %+v", clusterSettings.VitessSettings.API, keyspace, shard, err)
 				}
-				log.Debugf("Read %+v hosts from vitess %s, %s/%s", len(tablets), clusterSettings.VitessSettings.API, keyspace, shard)
+				log.Debugf("Read %+v hosts from vitess %s, %s/%s, cells=%s", len(tablets), clusterSettings.VitessSettings.API,
+					keyspace, shard, strings.Join(clusterSettings.VitessSettings.Cells, ","),
+				)
 				clusterProbes := &mysql.ClusterProbes{
 					ClusterName:      clusterName,
 					IgnoreHostsCount: clusterSettings.IgnoreHostsCount,

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -328,7 +328,7 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 					return log.Errorf("Unable to get vitess hosts from %s, %s/%s: %+v", clusterSettings.VitessSettings.API, keyspace, shard, err)
 				}
 				log.Debugf("Read %+v hosts from vitess %s, %s/%s, cells=%s", len(tablets), clusterSettings.VitessSettings.API,
-					keyspace, shard, strings.Join(clusterSettings.VitessSettings.Cells, ","),
+					keyspace, shard, strings.Join(vitess.ParseCells(clusterSettings.VitessSettings), ","),
 				)
 				clusterProbes := &mysql.ClusterProbes{
 					ClusterName:      clusterName,

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -24,11 +24,18 @@ type Tablet struct {
 
 // HasValidCell returns a bool reflecting if a tablet type is in a valid cell
 func (t Tablet) HasValidCell(validCells []string) bool {
-	if len(validCells) == 0 {
+	cells := make([]string, 0)
+	for _, cell := range validCells {
+		cell = strings.TrimSpace(cell)
+		if cell != "" {
+			cells = append(cells, cell)
+		}
+	}
+	if len(cells) == 0 {
 		return true
 	}
-	for _, cell := range validCells {
-		if t.Alias.GetCell() == strings.TrimSpace(cell) {
+	for _, cell := range cells {
+		if cell == "" || t.Alias.GetCell() == cell {
 			return true
 		}
 	}

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -35,7 +35,7 @@ func (t Tablet) HasValidCell(validCells []string) bool {
 		return true
 	}
 	for _, cell := range cells {
-		if cell == "" || t.Alias.GetCell() == cell {
+		if t.Alias.GetCell() == cell {
 			return true
 		}
 	}

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -44,7 +44,8 @@ func constructAPIURL(settings config.VitessConfigurationSettings) (url string) {
 // filterReplicaTablets parses a list of tablets, returning replica tablets only
 func filterReplicaTablets(settings config.VitessConfigurationSettings, tablets []Tablet) (replicas []Tablet) {
 	for _, tablet := range tablets {
-		if settings.Cell != "" && tablet.Alias.Cell != settings.Cell {
+		expectedCell := strings.TrimSpace(settings.Cell)
+		if expectedCell != "" && tablet.Alias.GetCell() != expectedCell {
 			continue
 		}
 		if tablet.IsValidReplica() {

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -22,7 +22,7 @@ type Tablet struct {
 	Type          topodata.TabletType   `json:"type,omitempty"`
 }
 
-// IsValidCell returns a bool reflecting if a tablet type is in a valid cell
+// HasValidCell returns a bool reflecting if a tablet type is in a valid cell
 func (t Tablet) HasValidCell(validCells []string) bool {
 	if len(validCells) == 0 {
 		return true

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -24,17 +24,10 @@ type Tablet struct {
 
 // HasValidCell returns a bool reflecting if a tablet is in a valid Vitess cell
 func (t Tablet) HasValidCell(validCells []string) bool {
-	cells := make([]string, 0)
-	for _, cell := range validCells {
-		cell = strings.TrimSpace(cell)
-		if cell != "" {
-			cells = append(cells, cell)
-		}
-	}
-	if len(cells) == 0 {
+	if len(validCells) == 0 {
 		return true
 	}
-	for _, cell := range cells {
+	for _, cell := range validCells {
 		if t.Alias.GetCell() == cell {
 			return true
 		}
@@ -61,10 +54,22 @@ func constructAPIURL(settings config.VitessConfigurationSettings) (url string) {
 	return url
 }
 
+// ParseCells returns a slice of non-empty Vitess cell names
+func ParseCells(settings config.VitessConfigurationSettings) (cells []string) {
+	for _, cell := range settings.Cells {
+		cell = strings.TrimSpace(cell)
+		if cell != "" {
+			cells = append(cells, cell)
+		}
+	}
+	return cells
+}
+
 // filterReplicaTablets parses a list of tablets, returning replica tablets only
 func filterReplicaTablets(settings config.VitessConfigurationSettings, tablets []Tablet) (replicas []Tablet) {
+	validCells := ParseCells(settings)
 	for _, tablet := range tablets {
-		if tablet.HasValidCell(settings.Cells) && tablet.IsValidReplica() {
+		if tablet.HasValidCell(validCells) && tablet.IsValidReplica() {
 			replicas = append(replicas, tablet)
 		}
 	}

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -22,7 +22,7 @@ type Tablet struct {
 	Type          topodata.TabletType   `json:"type,omitempty"`
 }
 
-// HasValidCell returns a bool reflecting if a tablet type is in a valid cell
+// HasValidCell returns a bool reflecting if a tablet is in a valid Vitess cell
 func (t Tablet) HasValidCell(validCells []string) bool {
 	cells := make([]string, 0)
 	for _, cell := range validCells {

--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -22,6 +22,19 @@ type Tablet struct {
 	Type          topodata.TabletType   `json:"type,omitempty"`
 }
 
+// IsValidCell returns a bool reflecting if a tablet type is in a valid cell
+func (t Tablet) HasValidCell(validCells []string) bool {
+	if len(validCells) == 0 {
+		return true
+	}
+	for _, cell := range validCells {
+		if t.Alias.GetCell() == strings.TrimSpace(cell) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsValidReplica returns a bool reflecting if a tablet type is REPLICA
 func (t Tablet) IsValidReplica() bool {
 	return t.Type == topodata.TabletType_REPLICA
@@ -44,11 +57,7 @@ func constructAPIURL(settings config.VitessConfigurationSettings) (url string) {
 // filterReplicaTablets parses a list of tablets, returning replica tablets only
 func filterReplicaTablets(settings config.VitessConfigurationSettings, tablets []Tablet) (replicas []Tablet) {
 	for _, tablet := range tablets {
-		expectedCell := strings.TrimSpace(settings.Cell)
-		if expectedCell != "" && tablet.Alias.GetCell() != expectedCell {
-			continue
-		}
-		if tablet.IsValidReplica() {
+		if tablet.HasValidCell(settings.Cells) && tablet.IsValidReplica() {
 			replicas = append(replicas, tablet)
 		}
 	}

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -24,12 +24,12 @@ func TestParseTablets(t *testing.T) {
 				},
 				{
 					Alias:         &topodata.TabletAlias{Cell: "ac4"},
-					MysqlHostname: "replica",
+					MysqlHostname: "replica1",
 					Type:          topodata.TabletType_REPLICA,
 				},
 				{
 					Alias:         &topodata.TabletAlias{Cell: "va3"},
-					MysqlHostname: "replica",
+					MysqlHostname: "replica2",
 					Type:          topodata.TabletType_REPLICA,
 				},
 				{
@@ -76,8 +76,11 @@ func TestParseTablets(t *testing.T) {
 			t.Fatalf("Expected 2 tablets, got %d", len(tablets))
 		}
 
-		if tablets[0].MysqlHostname != "replica" {
-			t.Fatalf("Expected hostname %q, got %q", "replica", tablets[0].MysqlHostname)
+		if tablets[0].MysqlHostname != "replica1" {
+			t.Fatalf("Expected hostname %q, got %q", "replica1", tablets[0].MysqlHostname)
+		}
+		if tablets[1].MysqlHostname != "replica2" {
+			t.Fatalf("Expected hostname %q, got %q", "replica2", tablets[1].MysqlHostname)
 		}
 
 		if httpClient.Timeout != time.Second {
@@ -100,9 +103,13 @@ func TestParseTablets(t *testing.T) {
 			t.Fatalf("Expected 1 tablet, got %d", len(tablets))
 		}
 
+		if tablets[0].MysqlHostname != "replica1" {
+			t.Fatalf("Expected hostname %q, got %q", "replica1", tablets[0].MysqlHostname)
+		}
 		if tablets[0].Alias.Cell != "ac4" {
 			t.Fatalf("Expected vitess cell %s, got %s", "ac4", tablets[0].Alias.Cell)
 		}
+
 	})
 
 	t.Run("not-found", func(t *testing.T) {

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -18,27 +18,37 @@ func TestParseTablets(t *testing.T) {
 		case "/api/keyspace/test/tablets/00":
 			data, _ := json.Marshal([]Tablet{
 				{
+					Alias:         &topodata.TabletAlias{Cell: "ash1"},
 					MysqlHostname: "master",
 					Type:          topodata.TabletType_MASTER,
 				},
 				{
+					Alias:         &topodata.TabletAlias{Cell: "ac4"},
 					MysqlHostname: "replica",
 					Type:          topodata.TabletType_REPLICA,
 				},
 				{
+					Alias:         &topodata.TabletAlias{Cell: "va3"},
+					MysqlHostname: "replica",
+					Type:          topodata.TabletType_REPLICA,
+				},
+				{
+					Alias:         &topodata.TabletAlias{Cell: "ac4"},
 					MysqlHostname: "spare",
 					Type:          topodata.TabletType_SPARE,
 				},
 				{
+					Alias:         &topodata.TabletAlias{Cell: "va3"},
 					MysqlHostname: "batch",
 					Type:          topodata.TabletType_BATCH,
 				},
 				{
+					Alias:         &topodata.TabletAlias{Cell: "ac4"},
 					MysqlHostname: "backup",
 					Type:          topodata.TabletType_BACKUP,
 				},
 				{
-
+					Alias:         &topodata.TabletAlias{Cell: "ash1"},
 					MysqlHostname: "restore",
 					Type:          topodata.TabletType_RESTORE,
 				},
@@ -62,8 +72,8 @@ func TestParseTablets(t *testing.T) {
 			t.Fatalf("Expected no error, got %q", err)
 		}
 
-		if len(tablets) != 1 {
-			t.Fatalf("Expected 1 tablet, got %d", len(tablets))
+		if len(tablets) != 2 {
+			t.Fatalf("Expected 2 tablets, got %d", len(tablets))
 		}
 
 		if tablets[0].MysqlHostname != "replica" {
@@ -72,6 +82,26 @@ func TestParseTablets(t *testing.T) {
 
 		if httpClient.Timeout != time.Second {
 			t.Fatalf("Expected vitess client timeout of %v, got %v", time.Second, httpClient.Timeout)
+		}
+	})
+
+	t.Run("with-cell", func(t *testing.T) {
+		tablets, err := ParseTablets(config.VitessConfigurationSettings{
+			API:      vitessApi.URL,
+			Cell:     "ac4",
+			Keyspace: "test",
+			Shard:    "00",
+		})
+		if err != nil {
+			t.Fatalf("Expected no error, got %q", err)
+		}
+
+		if len(tablets) > 1 {
+			t.Fatalf("Expected 1 tablet, got %d", len(tablets))
+		}
+
+		if tablets[0].Alias.Cell != "ac4" {
+			t.Fatalf("Expected vitess cell %s, got %s", "ac4", tablets[0].Alias.Cell)
 		}
 	})
 

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -18,37 +18,37 @@ func TestParseTablets(t *testing.T) {
 		case "/api/keyspace/test/tablets/00":
 			data, _ := json.Marshal([]Tablet{
 				{
-					Alias:         &topodata.TabletAlias{Cell: "ash1"},
+					Alias:         &topodata.TabletAlias{Cell: "cell1"},
 					MysqlHostname: "master",
 					Type:          topodata.TabletType_MASTER,
 				},
 				{
-					Alias:         &topodata.TabletAlias{Cell: "ac4"},
+					Alias:         &topodata.TabletAlias{Cell: "cell2"},
 					MysqlHostname: "replica1",
 					Type:          topodata.TabletType_REPLICA,
 				},
 				{
-					Alias:         &topodata.TabletAlias{Cell: "va3"},
+					Alias:         &topodata.TabletAlias{Cell: "cell3"},
 					MysqlHostname: "replica2",
 					Type:          topodata.TabletType_REPLICA,
 				},
 				{
-					Alias:         &topodata.TabletAlias{Cell: "ac4"},
+					Alias:         &topodata.TabletAlias{Cell: "cell2"},
 					MysqlHostname: "spare",
 					Type:          topodata.TabletType_SPARE,
 				},
 				{
-					Alias:         &topodata.TabletAlias{Cell: "va3"},
+					Alias:         &topodata.TabletAlias{Cell: "cell3"},
 					MysqlHostname: "batch",
 					Type:          topodata.TabletType_BATCH,
 				},
 				{
-					Alias:         &topodata.TabletAlias{Cell: "ac4"},
+					Alias:         &topodata.TabletAlias{Cell: "cell2"},
 					MysqlHostname: "backup",
 					Type:          topodata.TabletType_BACKUP,
 				},
 				{
-					Alias:         &topodata.TabletAlias{Cell: "ash1"},
+					Alias:         &topodata.TabletAlias{Cell: "cell1"},
 					MysqlHostname: "restore",
 					Type:          topodata.TabletType_RESTORE,
 				},
@@ -91,7 +91,7 @@ func TestParseTablets(t *testing.T) {
 	t.Run("with-cell", func(t *testing.T) {
 		tablets, err := ParseTablets(config.VitessConfigurationSettings{
 			API:      vitessApi.URL,
-			Cell:     "ac4",
+			Cell:     "cell2",
 			Keyspace: "test",
 			Shard:    "00",
 		})
@@ -106,8 +106,8 @@ func TestParseTablets(t *testing.T) {
 		if tablets[0].MysqlHostname != "replica1" {
 			t.Fatalf("Expected hostname %q, got %q", "replica1", tablets[0].MysqlHostname)
 		}
-		if tablets[0].Alias.Cell != "ac4" {
-			t.Fatalf("Expected vitess cell %s, got %s", "ac4", tablets[0].Alias.Cell)
+		if tablets[0].Alias.Cell != "cell2" {
+			t.Fatalf("Expected vitess cell %s, got %s", "cell2", tablets[0].Alias.Cell)
 		}
 
 	})

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -89,12 +89,13 @@ func TestParseTablets(t *testing.T) {
 	})
 
 	t.Run("with-cell", func(t *testing.T) {
-		tablets, err := ParseTablets(config.VitessConfigurationSettings{
+		settings := config.VitessConfigurationSettings{
 			API:      vitessApi.URL,
 			Cells:    []string{"cell2"},
 			Keyspace: "test",
 			Shard:    "00",
-		})
+		}
+		tablets, err := ParseTablets(settings)
 		if err != nil {
 			t.Fatalf("Expected no error, got %q", err)
 		}
@@ -106,8 +107,15 @@ func TestParseTablets(t *testing.T) {
 		if tablets[0].MysqlHostname != "replica1" {
 			t.Fatalf("Expected hostname %q, got %q", "replica1", tablets[0].MysqlHostname)
 		}
-		if tablets[0].Alias.Cell != "cell2" {
-			t.Fatalf("Expected vitess cell %s, got %s", "cell2", tablets[0].Alias.Cell)
+		if tablets[0].Alias.GetCell() != "cell2" {
+			t.Fatalf("Expected vitess cell %s, got %s", "cell2", tablets[0].Alias.GetCell())
+		}
+
+		// empty cell names should cause no filtering
+		settings.Cells = []string{"", ""}
+		tablets, _ = ParseTablets(settings)
+		if len(tablets) != 2 {
+			t.Fatalf("Expected 2 tablet, got %d", len(tablets))
 		}
 	})
 

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -99,7 +99,7 @@ func TestParseTablets(t *testing.T) {
 			t.Fatalf("Expected no error, got %q", err)
 		}
 
-		if len(tablets) > 1 {
+		if len(tablets) != 1 {
 			t.Fatalf("Expected 1 tablet, got %d", len(tablets))
 		}
 

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -91,7 +91,7 @@ func TestParseTablets(t *testing.T) {
 	t.Run("with-cell", func(t *testing.T) {
 		tablets, err := ParseTablets(config.VitessConfigurationSettings{
 			API:      vitessApi.URL,
-			Cell:     "cell2",
+			Cells:    []string{"cell2"},
 			Keyspace: "test",
 			Shard:    "00",
 		})
@@ -109,7 +109,6 @@ func TestParseTablets(t *testing.T) {
 		if tablets[0].Alias.Cell != "cell2" {
 			t.Fatalf("Expected vitess cell %s, got %s", "cell2", tablets[0].Alias.Cell)
 		}
-
 	})
 
 	t.Run("not-found", func(t *testing.T) {


### PR DESCRIPTION
This PR adds support for polling MySQL replicas from a specific [Vitess "cell"](https://vitess.io/docs/concepts/cell/)

This change is backwards compatible with the current logic that fetches replicas from any Vitess cell. This change resolves duplicated Freno probing when Freno is deployed with a share domain and many Vitess cells