### PR TITLE
Vitess: handle non-200 HTTP status in ParseTablets()

### DIFF
--- a/pkg/vitess/api_client.go
+++ b/pkg/vitess/api_client.go
@@ -71,7 +71,7 @@ func filterReplicaTablets(settings config.VitessConfigurationSettings, tablets [
 	return replicas
 }
 
-// ParseTablets reads from vitess /api/ks_tablets/<keyspace>/[shard] and returns a
+// ParseTablets reads from vitess /api/keyspace/<keyspace>/tablets/[shard] and returns a
 // listing (mysql_hostname, mysql_port, type) of REPLICA tablets
 func ParseTablets(settings config.VitessConfigurationSettings) (tablets []Tablet, err error) {
 	if settings.TimeoutSecs == 0 {
@@ -85,13 +85,16 @@ func ParseTablets(settings config.VitessConfigurationSettings) (tablets []Tablet
 	if err != nil {
 		return tablets, err
 	}
-
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return tablets, fmt.Errorf("%v", resp.Status)
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return tablets, err
 	}
-
 	err = json.Unmarshal(body, &tablets)
 	return filterReplicaTablets(settings, tablets), err
 }

--- a/pkg/vitess/api_client_test.go
+++ b/pkg/vitess/api_client_test.go
@@ -56,7 +56,6 @@ func TestParseTablets(t *testing.T) {
 			fmt.Fprint(w, string(data))
 		default:
 			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, "[]")
 		}
 	}))
 	defer vitessApi.Close()
@@ -125,11 +124,11 @@ func TestParseTablets(t *testing.T) {
 			Keyspace: "not-found",
 			Shard:    "40-80",
 		})
-		if err != nil {
-			t.Fatalf("Expected no error, got %q", err)
+		if err == nil || err.Error() != "404 Not Found" {
+			t.Fatalf("Expected %q error, got %q", "404 Not Found", err)
 		}
 
-		if len(tablets) > 0 {
+		if len(tablets) != 0 {
 			t.Fatalf("Expected 0 tablets, got %d", len(tablets))
 		}
 


### PR DESCRIPTION
This PR fixes a strange error when a Vitess API returns a `404 Not Found` for a missing keyspace:
```
2020-07-22 13:34:06 ERROR Unable to get vitess hosts from https://<hostname>/api, <keyspace>/: invalid character 'p' after top-level value
```

Now the HTTP status line is returned as an error unless a `200 OK` is returned