### PR TITLE
Update build.sh for new code dirs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -100,7 +100,7 @@ function oinstall() {
   prefix="$2"
 
   cd  $mydir
-  gofmt -s -w  go/
+  gofmt -s -w pkg/
   cp ./resources/etc/init.d/freno $builddir/freno/etc/init.d/freno
   chmod +x $builddir/freno/etc/init.d/freno
   cp ./resources/freno.conf.skeleton.json $builddir/freno/etc/freno.conf.json
@@ -143,7 +143,7 @@ function build() {
   prefix="$4"
   ldflags="-X main.AppVersion=${RELEASE_VERSION} -X main.GitCommit=${GIT_COMMIT}"
   echo "Building via $(go version)"
-  gobuild="go build -i ${opt_race} -ldflags \"$ldflags\" -o $builddir/freno${prefix}/freno go/cmd/freno/main.go"
+  gobuild="go build -i ${opt_race} -ldflags \"$ldflags\" -o $builddir/freno${prefix}/freno cmd/freno/main.go"
 
   case $os in
     'linux')


### PR DESCRIPTION
This PR updates `build.sh` for the path changes made in https://github.com/github/freno/pull/117

Specifically `go/` was renamed to `pkg/` and `go/cmd/freno/main.go` became `cmd/freno/main.go`

Today `build.sh` errors with:
```
tim@Tims-MacBook-Pro freno % bash build.sh                                        
stat go/: no such file or directory
```