### PR TITLE
Restore .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# http://docs.travis-ci.com/user/languages/go/
+language: go
+
+go: 1.14.x
+
+os:
+  - linux
+
+install: true
+
+script: script/cibuild
+
+notifications:
+  email: false


### PR DESCRIPTION
This PR restores `.travis.yml` that was dropped in https://github.com/github/freno/pull/127

This is still needed for the build health badge