### PR TITLE
Add -version flag, print version

### DIFF
--- a/cmd/freno/main.go
+++ b/cmd/freno/main.go
@@ -16,9 +16,15 @@ import (
 // AppVersion has to be filled by ldflags:
 var AppVersion string
 
+// GitCommit represents the git commit of Freno
+var GitCommit string
+
 func main() {
 	if AppVersion == "" {
 		AppVersion = "local-build"
+	}
+	if GitCommit == "" {
+		GitCommit = "unknown"
 	}
 
 	configFile := flag.String("config", "", "config file name")
@@ -34,6 +40,7 @@ func main() {
 	forceLeadership := flag.Bool("force-leadership", false, "Make this node consider itself a leader no matter what consensus logic says")
 
 	quiet := flag.Bool("quiet", false, "quiet")
+	version := flag.Bool("version", false, "print version")
 	verbose := flag.Bool("verbose", false, "verbose")
 	debug := flag.Bool("debug", false, "debug mode (very verbose)")
 	stack := flag.Bool("stack", false, "add stack trace upon error")
@@ -44,6 +51,10 @@ func main() {
 
 	if *help {
 		printUsage()
+		return
+	}
+	if *version {
+		fmt.Printf("freno version %s, git commit %s\n", AppVersion, GitCommit)
 		return
 	}
 
@@ -61,7 +72,7 @@ func main() {
 		// Override!!
 		log.SetLevel(log.ERROR)
 	}
-	log.Infof("starting freno %s", AppVersion)
+	log.Infof("starting freno %s, git commit %s", AppVersion, GitCommit)
 
 	loadConfiguration(*configFile)
 


### PR DESCRIPTION
This PR adds a `-version` flag for printing the Freno version:
```
$ freno -version
freno version 1.0.5, git commit 48a765a4d63924a835269665cded456679e357a6
```

Also, the git commit is added to [the `starting freno` log line](https://github.com/github/freno/compare/add-version-flag?expand=1#diff-d89c1853247e7fc229e2585a95a5271fR75)