### PR TITLE
Allow pprof profiling HTTP API

### DIFF
--- a/cmd/freno/main.go
+++ b/cmd/freno/main.go
@@ -133,7 +133,7 @@ func httpServe() error {
 	throttlerCheck := throttle.NewThrottlerCheck(throttler)
 	throttlerCheck.SelfChecks()
 	api := http.NewAPIImpl(throttlerCheck, consensusServiceProvider.GetConsensusService())
-	router := http.ConfigureRoutes(api, config.Settings().EnableProfiling)
+	router := http.ConfigureRoutes(api)
 	port := config.Settings().ListenPort
 	log.Infof("Starting server in port %d", port)
 	return gohttp.ListenAndServe(fmt.Sprintf(":%d", port), router)

--- a/cmd/freno/main.go
+++ b/cmd/freno/main.go
@@ -44,7 +44,7 @@ func main() {
 	verbose := flag.Bool("verbose", false, "verbose")
 	debug := flag.Bool("debug", false, "debug mode (very verbose)")
 	stack := flag.Bool("stack", false, "add stack trace upon error")
-	enableProfiling := flag.Bool("enable-profiling", false, "enable pprof profiling")
+	enableProfiling := flag.Bool("enable-profiling", false, "enable pprof profiling http api")
 
 	help := flag.Bool("help", false, "show the help")
 	flag.Parse()

--- a/cmd/freno/main.go
+++ b/cmd/freno/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	switch {
 	case *http:
-		err := httpServe(config.Settings())
+		err := httpServe()
 		log.Errore(err)
 	default:
 		printUsage()
@@ -116,7 +116,7 @@ func loadConfiguration(configFile string) {
 	}
 }
 
-func httpServe(settings *config.ConfigurationSettings) error {
+func httpServe() error {
 	throttler := throttle.NewThrottler()
 	log.Infof("Starting consensus service")
 	log.Infof("- forced leadership: %+v", group.ForceLeadership)
@@ -133,7 +133,7 @@ func httpServe(settings *config.ConfigurationSettings) error {
 	throttlerCheck := throttle.NewThrottlerCheck(throttler)
 	throttlerCheck.SelfChecks()
 	api := http.NewAPIImpl(throttlerCheck, consensusServiceProvider.GetConsensusService())
-	router := http.ConfigureRoutes(api, settings.EnableProfiling)
+	router := http.ConfigureRoutes(api, config.Settings().EnableProfiling)
 	port := config.Settings().ListenPort
 	log.Infof("Starting server in port %d", port)
 	return gohttp.ListenAndServe(fmt.Sprintf(":%d", port), router)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,7 +108,7 @@ type ConfigurationSettings struct {
 	BackendMySQLPassword string
 	MemcacheServers      []string // if given, freno will report to aggregated values to given memcache
 	MemcachePath         string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
-	EnableProfiling      bool     // enable pprof http APIs for profiling
+	EnableProfiling      bool     // enable pprof profiling http api
 	Stores               StoresSettings
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,7 @@ type ConfigurationSettings struct {
 	BackendMySQLPassword string
 	MemcacheServers      []string // if given, freno will report to aggregated values to given memcache
 	MemcachePath         string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
+	EnableProfiling      bool     // enable pprof http APIs for profiling
 	Stores               StoresSettings
 }
 

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"strconv"
 	"strings"
@@ -336,7 +337,7 @@ func metricsHandle(w http.ResponseWriter, r *http.Request, p httprouter.Params) 
 
 // ConfigureRoutes configures a set of HTTP routes to be actions dispatched by the
 // given api's methods.
-func ConfigureRoutes(api API) *httprouter.Router {
+func ConfigureRoutes(api API, enableProfiling bool) *httprouter.Router {
 	router := httprouter.New()
 	register(router, "/lb-check", api.LbCheck)
 	register(router, "/_ping", api.LbCheck)
@@ -369,6 +370,18 @@ func ConfigureRoutes(api API) *httprouter.Router {
 
 	register(router, "/debug/vars", metricsHandle)
 	register(router, "/debug/metrics", metricsHandle)
+
+	if enableProfiling {
+		router.HandlerFunc(http.MethodGet, "/debug/pprof/", pprof.Index)
+		router.HandlerFunc(http.MethodGet, "/debug/pprof/cmdline", pprof.Cmdline)
+		router.HandlerFunc(http.MethodGet, "/debug/pprof/profile", pprof.Profile)
+		router.HandlerFunc(http.MethodGet, "/debug/pprof/symbol", pprof.Symbol)
+		router.HandlerFunc(http.MethodGet, "/debug/pprof/trace", pprof.Trace)
+		router.Handler(http.MethodGet, "/debug/pprof/goroutine", pprof.Handler("goroutine"))
+		router.Handler(http.MethodGet, "/debug/pprof/heap", pprof.Handler("heap"))
+		router.Handler(http.MethodGet, "/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+		router.Handler(http.MethodGet, "/debug/pprof/block", pprof.Handler("block"))
+	}
 
 	register(router, "/help", api.Help)
 

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -337,7 +337,7 @@ func metricsHandle(w http.ResponseWriter, r *http.Request, p httprouter.Params) 
 
 // ConfigureRoutes configures a set of HTTP routes to be actions dispatched by the
 // given api's methods.
-func ConfigureRoutes(api API, enableProfiling bool) *httprouter.Router {
+func ConfigureRoutes(api API) *httprouter.Router {
 	router := httprouter.New()
 	register(router, "/lb-check", api.LbCheck)
 	register(router, "/_ping", api.LbCheck)
@@ -371,7 +371,7 @@ func ConfigureRoutes(api API, enableProfiling bool) *httprouter.Router {
 	register(router, "/debug/vars", metricsHandle)
 	register(router, "/debug/metrics", metricsHandle)
 
-	if enableProfiling {
+	if config.Settings().EnableProfiling {
 		router.HandlerFunc(http.MethodGet, "/debug/pprof/", pprof.Index)
 		router.HandlerFunc(http.MethodGet, "/debug/pprof/cmdline", pprof.Cmdline)
 		router.HandlerFunc(http.MethodGet, "/debug/pprof/profile", pprof.Profile)

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -28,7 +28,7 @@ func TestLbCheck(t *testing.T) {
 
 // TestRoutes applies an end-to-end canary test over each of the different routes
 func TestRoutes(t *testing.T) {
-	router := ConfigureRoutes(new(APIImpl))
+	router := ConfigureRoutes(new(APIImpl), false)
 
 	expectedRoutes := []struct {
 		verb string

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -28,7 +28,7 @@ func TestLbCheck(t *testing.T) {
 
 // TestRoutes applies an end-to-end canary test over each of the different routes
 func TestRoutes(t *testing.T) {
-	router := ConfigureRoutes(new(APIImpl), false)
+	router := ConfigureRoutes(new(APIImpl))
 
 	expectedRoutes := []struct {
 		verb string


### PR DESCRIPTION
This PR allows Freno to expose the [`net/http/pprof`](https://golang.org/pkg/net/http/pprof/) HTTP API for profiling Golang applications

This is an optional feature enabled by `-enable-profiling` or `EnableProfiling: true` in the config file

This allows `go tool pprof` to be used against Freno, example:
```
tim@Tims-MacBook-Pro freno % go tool pprof 'http://localhost:8088/debug/pprof/profile?seconds=10'
Fetching profile over HTTP from http://localhost:8088/debug/pprof/profile?seconds=10
Saved profile in /Users/tim/pprof/pprof.samples.cpu.003.pb.gz
Type: cpu
Time: Aug 18, 2020 at 9:23pm (CEST)
Duration: 10s, Total samples = 130ms ( 1.30%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 130ms, 100% of 130ms total
Showing top 10 nodes out of 24
      flat  flat%   sum%        cum   cum%
      40ms 30.77% 30.77%       40ms 30.77%  runtime.kevent
      40ms 30.77% 61.54%       40ms 30.77%  runtime.nanotime1
      20ms 15.38% 76.92%       20ms 15.38%  runtime.usleep
      10ms  7.69% 84.62%       10ms  7.69%  runtime.pthread_cond_signal
      10ms  7.69% 92.31%       10ms  7.69%  runtime.pthread_cond_timedwait_relative_np
      10ms  7.69%   100%       10ms  7.69%  runtime.read
         0     0%   100%       10ms  7.69%  runtime.checkTimers
         0     0%   100%       70ms 53.85%  runtime.findrunnable
         0     0%   100%       80ms 61.54%  runtime.mcall
         0     0%   100%       50ms 38.46%  runtime.mstart
```

cc @shlomi-noach / @gtowey 