### PR TITLE
Add 'maintainter' to .goreleaser.yml to fix install warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ changelog:
 nfpms:
   - vendor: GitHub
     homepage: https://github.com/github/freno
+    maintainer: GitHub Engineering <github@github.com>
     description: Cooperative, highly available throttler service
     license: MIT
     bindir: /usr/bin


### PR DESCRIPTION
This resolves a warning for a missing `maintainer` on package-install of v1.0.5

Merging straight to master as there is no logic change here 👍 