### PR TITLE
Add release name template to goreleaser, build amd64 only

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,7 @@ nfpms:
       - deb
       - rpm
 release:
+  name_template: "GA release {{.Tag}}"
   github:
     owner: github
     name: freno

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ before:
 builds:
 - env:
     - CGO_ENABLED=0
+  goarch:
+    - amd64
   goos:
     - linux
     - darwin


### PR DESCRIPTION
This PR adds release name template for release builds and creates amd64-based binaries only