### PR TITLE
Golang 1.15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.14.x
+go: 1.15.x
 
 os:
   - linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine
+FROM golang:1.15-alpine
 
 COPY . /go/src/github.com/github/freno
 WORKDIR /go/src/github.com/github/freno

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.15-stretch
+FROM golang:1.15-buster
 LABEL maintainer="github@github.com"
 
 RUN useradd -m testuser

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.14-stretch
+FROM golang:1.15-stretch
 LABEL maintainer="github@github.com"
 
 RUN useradd -m testuser

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/freno
 
-go 1.14
+go 1.15
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,7 +2,7 @@
 
 set -e
 
-readonly supportedGo="go1.1[234]"
+readonly supportedGo="go1.1[2345]"
 
 # Ensure go is installed
 if ! command -v go ; then

--- a/script/build-deploy-tarball
+++ b/script/build-deploy-tarball
@@ -29,7 +29,7 @@ mkdir -p "$BUILD_ARTIFACT_DIR"/freno
 cp ${tarball}.gz "$BUILD_ARTIFACT_DIR"/freno/
 
 ### HACK HACK HACK ###
-# blame @carlosmn and @mattr-
-# Allow builds on stretch to also be used for jessie
-jessie_tarball_name=$(echo $(basename "${tarball}") | sed s/-stretch-/-jessie-/)
-cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/freno/${jessie_tarball_name}.gz"
+# blame @carlosmn, @mattr and @timvaillancourt-
+# Allow builds on buster to also be used for stretch
+stretch_tarball_name=$(echo $(basename "${tarball}") | sed s/-buster-/-stretch-/)
+cp ${tarball}.gz "$BUILD_ARTIFACT_DIR/freno/${stretch_tarball_name}.gz"


### PR DESCRIPTION
This PR updates the build/test steps to use Golang 1.15

The docker image `golang:1.15-buster` uses a new Debian release so this PR makes a copy of `buster`->`stretch`. The `jessie` tarball was removed because it is EOL