### PR TITLE
Update `.goreleaser.yml` NFPM syntax

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,7 @@ nfpms:
     contents:
       - src: "resources/freno.conf.skeleton.json"
         dst: "/etc/freno.conf.json"
+        type: config
       - src: "resources/etc/init.d/freno"
         dst: "/etc/init.d/freno"
         file_info:


### PR DESCRIPTION
This PR corrects a YAML syntax error in `.goreleaser.yml` that is preventing new releases from being auto-generated:
```
   ⨯ release failed after 0.00s error=yaml: unmarshal errors:
  line 28: field config_files not found in type config.NFPM
  line 30: field files not found in type config.NFPM
```

It turns out goreleaser changed the syntax of the `nfpm` section of the config file. This PR corrects this

Updated format: https://goreleaser.com/customization/nfpm/