### PR TITLE
refactor: use `os.ReadDir` for lightweight directory reading

### DIFF
--- a/internal/raft/file_snapshot.go
+++ b/internal/raft/file_snapshot.go
@@ -8,7 +8,6 @@ import (
 	"hash"
 	"hash/crc64"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -214,7 +213,7 @@ func (f *FileSnapshotStore) List() ([]*SnapshotMeta, error) {
 // getSnapshots returns all the known snapshots.
 func (f *FileSnapshotStore) getSnapshots() ([]*fileSnapshotMeta, error) {
 	// Get the eligible snapshots
-	snapshots, err := ioutil.ReadDir(f.path)
+	snapshots, err := os.ReadDir(f.path)
 	if err != nil {
 		f.logger.Printf("[ERR] snapshot: Failed to scan snapshot dir: %v", err)
 		return nil, err

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,7 +2,7 @@
 
 set -e
 
-readonly supportedGo="go1.1[567]"
+readonly supportedGo="go1.1[67]"
 
 # Ensure go is installed
 if ! command -v go ; then


### PR DESCRIPTION
`os.ReadDir` is a more efficient than `ioutil.ReadDir` as stated here https://pkg.go.dev/io/ioutil#ReadDir. Since we are only using `IsDir()` and `Name()` in `getSnapshots`, we don't need to read the directory with full stat information using `ioutil.ReadDir`.