### PR TITLE
Skip hosts API

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -72,8 +72,8 @@ function precheck() {
     ok=1
   fi
 
-  if ! go version | egrep -q 'go(1\.1[234])' ; then
-    echo "go version must be 1.12 or above"
+  if ! go version | egrep -q 'go(1\.1[6789])' ; then
+    echo "go version must be 1.16 or above"
     ok=1
   fi
 

--- a/doc/http.md
+++ b/doc/http.md
@@ -101,6 +101,11 @@ Notes:
 
 - `/check-read-if-exists/<app>/<store-type>/<store-name>/<threshold>`: like `/check-read`, but if the metric is unknown (e.g. `<store-name>` not in `freno`'s configuration), return `200 OK`. This is useful for hybrid systems where some metrics need to be strictly controlled, and some not. `freno` would probe the important stores, and still can serve requests for all stores.
 
+- `/skip-host/<hostname>/ttl/<ttl-minutes>`: skip host when aggregating metrics for specified number of minutes. If host is already skipped, update the TTL.
+- `/skip-host/<hostname>`: same as `/skip-host/<hostname>/ttl/60`
+- `/recover-host/<hostname>`: recover a previously skipped host.
+- `/skipped-hosts`:  list currently skipped hosts
+
 ### Other requests
 
 - `/help`: show all supported request paths

--- a/doc/mysql-backend.md
+++ b/doc/mysql-backend.md
@@ -82,6 +82,14 @@ CREATE TABLE throttled_apps (
 	ratio DOUBLE,
   PRIMARY KEY (app_name)
 );
+
+CREATE TABLE skipped_hosts (
+   host_name varchar(128) NOT NULL,
+   skipped_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+   expires_at TIMESTAMP NOT NULL,
+
+   PRIMARY KEY (host_name)
+);
 ```
 
 The `BackendMySQLUser` account must have `SELECT, INSERT, DELETE, UPDATE` privileges on those tables.

--- a/pkg/group/consensus_service.go
+++ b/pkg/group/consensus_service.go
@@ -28,7 +28,7 @@ type ConsensusService interface {
 	UnthrottleApp(appName string) error
 	RecentAppsMap() (result map[string](*base.RecentApp))
 
-	SkipHost(hostName string, expireAt time.Time) error
+	SkipHost(hostName string, ttlMinutes int64, expireAt time.Time) error
 	RecoverHost(hostName string) error
 	SkippedHostsMap() (result map[string]time.Time)
 

--- a/pkg/group/consensus_service.go
+++ b/pkg/group/consensus_service.go
@@ -28,6 +28,10 @@ type ConsensusService interface {
 	UnthrottleApp(appName string) error
 	RecentAppsMap() (result map[string](*base.RecentApp))
 
+	SkipHost(hostName string, expireAt time.Time) error
+	RecoverHost(hostName string) error
+	SkippedHostsMap() (result map[string]time.Time)
+
 	IsHealthy() bool
 	IsLeader() bool
 	GetLeader() string

--- a/pkg/group/fsm_snapshot.go
+++ b/pkg/group/fsm_snapshot.go
@@ -2,6 +2,7 @@ package group
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/github/freno/pkg/base"
 
@@ -12,11 +13,13 @@ import (
 // it will mostly duplicate data stored in `throttler`.
 type snapshotData struct {
 	throttledApps map[string](base.AppThrottle)
+	skippedHosts  map[string]time.Time
 }
 
 func newSnapshotData() *snapshotData {
 	return &snapshotData{
 		throttledApps: make(map[string](base.AppThrottle)),
+		skippedHosts:  make(map[string]time.Time),
 	}
 }
 

--- a/pkg/group/mysql.go
+++ b/pkg/group/mysql.go
@@ -389,6 +389,21 @@ func (backend *MySQLBackend) UnthrottleApp(appName string) error {
 	return err
 }
 
+func (backend *MySQLBackend) SkipHost(hostName string, expireAt time.Time) error {
+	//TODO
+	return nil
+}
+
+func (backend *MySQLBackend) RecoverHost(hostName string) error {
+	//TODO
+	return nil
+}
+
+func (backend *MySQLBackend) SkippedHostsMap() map[string]time.Time {
+	//TODO
+	return nil
+}
+
 func (backend *MySQLBackend) RecentAppsMap() (result map[string](*base.RecentApp)) {
 	return backend.throttler.RecentAppsMap()
 }

--- a/pkg/group/mysql.go
+++ b/pkg/group/mysql.go
@@ -28,6 +28,13 @@ CREATE TABLE throttled_apps (
 	ratio DOUBLE,
   PRIMARY KEY (app_name)
 );
+
+CREATE TABLE skipped_hosts (
+   host_name varchar(128) NOT NULL,
+   skipped_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+   expires_at TIMESTAMP NOT NULL,
+   PRIMARY KEY (host_name)
+);
 */
 
 package group
@@ -145,6 +152,7 @@ func (backend *MySQLBackend) onLeaderStateChange(newLeaderState int64) error {
 	if newLeaderState > 0 {
 		log.Infof("Transitioned into leader state")
 		backend.readThrottledApps()
+		backend.readSkippedHosts()
 	} else {
 		log.Infof("Transitioned out of leader state")
 	}
@@ -343,6 +351,24 @@ func (backend *MySQLBackend) readThrottledApps() error {
 	return err
 }
 
+func (backend *MySQLBackend) readSkippedHosts() error {
+	query := `
+        select
+            host_name,
+            timestampdiff(second, now(), expires_at) as ttl_seconds
+        from
+            skipped_hosts
+            `
+	err := sqlutils.QueryRowsMap(backend.db, query, func(m sqlutils.RowMap) error {
+		hostName := m.GetString("host_name")
+		ttlSeconds := m.GetInt64("ttl_seconds")
+		expireAt := time.Now().Add(time.Duration(ttlSeconds) * time.Second)
+		go backend.throttler.SkipHost(hostName, expireAt)
+		return nil
+	})
+	return err
+}
+
 func (backend *MySQLBackend) ThrottleApp(appName string, ttlMinutes int64, expireAt time.Time, ratio float64) error {
 	log.Debugf("throttle-app: app=%s, ttlMinutes=%+v, expireAt=%+v, ratio=%+v", appName, ttlMinutes, expireAt, ratio)
 	var query string
@@ -389,19 +415,34 @@ func (backend *MySQLBackend) UnthrottleApp(appName string) error {
 	return err
 }
 
-func (backend *MySQLBackend) SkipHost(hostName string, expireAt time.Time) error {
-	//TODO
-	return nil
+func (backend *MySQLBackend) SkipHost(hostName string, ttlMinutes int64, expireAt time.Time) error {
+	backend.throttler.SkipHost(hostName, expireAt)
+	query := `
+	    replace into skipped_hosts (
+	        host_name, skipped_at, expires_at
+	      ) values (
+	        ?, now(), now() + interval ? minute
+	      )`
+
+	ttl := ttlMinutes
+	if ttlMinutes == 0 {
+		ttl = throttle.DefaultSkipTTLMinutes
+	}
+	args := sqlutils.Args(hostName, ttl)
+	_, err := sqlutils.ExecNoPrepare(backend.db, query, args...)
+	return err
 }
 
 func (backend *MySQLBackend) RecoverHost(hostName string) error {
-	//TODO
-	return nil
+	backend.throttler.RecoverHost(hostName)
+	query := `update skipped_hosts set expires_at=now() where host_name=?`
+	args := sqlutils.Args(hostName)
+	_, err := sqlutils.ExecNoPrepare(backend.db, query, args...)
+	return err
 }
 
 func (backend *MySQLBackend) SkippedHostsMap() map[string]time.Time {
-	//TODO
-	return nil
+	return backend.throttler.SkippedHostsMap()
 }
 
 func (backend *MySQLBackend) RecentAppsMap() (result map[string](*base.RecentApp)) {

--- a/pkg/group/store.go
+++ b/pkg/group/store.go
@@ -19,7 +19,7 @@ import (
 	"github.com/github/freno/pkg/throttle"
 
 	"github.com/github/freno/internal/raft"
-	"github.com/github/freno/internal/raft-boltdb"
+	raftboltdb "github.com/github/freno/internal/raft-boltdb"
 	"github.com/outbrain/golib/log"
 	metrics "github.com/rcrowley/go-metrics"
 )
@@ -154,6 +154,27 @@ func (store *Store) UnthrottleApp(appName string) error {
 		Key:       appName,
 	}
 	return store.genericCommand(c)
+}
+
+func (store *Store) SkipHost(hostName string, expireAt time.Time) error {
+	c := &command{
+		Operation: "skip",
+		Key:       hostName,
+		ExpireAt:  expireAt,
+	}
+	return store.genericCommand(c)
+}
+
+func (store *Store) RecoverHost(hostName string) error {
+	c := &command{
+		Operation: "recover",
+		Key:       hostName,
+	}
+	return store.genericCommand(c)
+}
+
+func (store *Store) SkippedHostsMap() map[string]time.Time {
+	return store.throttler.SkippedHostsMap()
 }
 
 func (store *Store) ThrottledAppsMap() (result map[string](*base.AppThrottle)) {

--- a/pkg/group/store.go
+++ b/pkg/group/store.go
@@ -156,7 +156,7 @@ func (store *Store) UnthrottleApp(appName string) error {
 	return store.genericCommand(c)
 }
 
-func (store *Store) SkipHost(hostName string, expireAt time.Time) error {
+func (store *Store) SkipHost(hostName string, ttlMinutes int64, expireAt time.Time) error {
 	c := &command{
 		Operation: "skip",
 		Key:       hostName,

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -405,7 +405,7 @@ func ConfigureRoutes(api API) *httprouter.Router {
 	register(router, "/recent-apps/:lastMinutes", api.RecentApps)
 
 	register(router, "/skip-host/:hostName", api.SkipHost)
-	register(router, "/skipped-hosts/:hostName/ttl/:ttlMinutes", api.SkipHost)
+	register(router, "/skip-host/:hostName/ttl/:ttlMinutes", api.SkipHost)
 	register(router, "/skipped-hosts", api.SkippedHosts)
 	register(router, "/recover-host/:hostName", api.RecoverHost)
 

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -199,7 +199,7 @@ func (api *APIImpl) ReadCheck(w http.ResponseWriter, r *http.Request, ps httprou
 	api.readCheck(w, r, ps, &throttle.CheckFlags{})
 }
 
-// WriteCheckIfExists checks for a metric, but reports an OK if the metric does not exist.
+// ReadCheckIfExists checks for a metric, but reports an OK if the metric does not exist.
 // If the metric does exist, then all usual checks are made.
 func (api *APIImpl) ReadCheckIfExists(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	api.readCheck(w, r, ps, &throttle.CheckFlags{OKIfNotExists: true})
@@ -354,7 +354,7 @@ func (api *APIImpl) SkipHost(w http.ResponseWriter, r *http.Request, ps httprout
 		expireAt = time.Now().Add(time.Duration(ttlMinutes) * time.Minute)
 	}
 
-	err = api.consensusService.SkipHost(hostName, expireAt)
+	err = api.consensusService.SkipHost(hostName, ttlMinutes, expireAt)
 
 	api.respondGeneric(w, r, err)
 }

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -36,6 +36,9 @@ type API interface {
 	ThrottleApp(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	UnthrottleApp(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	ThrottledApps(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
+	SkipHost(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
+	SkippedHosts(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
+	RecoverHost(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	RecentApps(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	Help(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	MemcacheConfig(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
@@ -335,6 +338,39 @@ func metricsHandle(w http.ResponseWriter, r *http.Request, p httprouter.Params) 
 	handler.ServeHTTP(w, r)
 }
 
+func (api *APIImpl) SkipHost(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	var ttlMinutes int64
+	var expireAt time.Time
+	var err error
+
+	hostName := ps.ByName("hostName")
+	ttlString := ps.ByName("ttlMinutes")
+	if ttlString == "" {
+		ttlMinutes = 0
+	} else if ttlMinutes, err = strconv.ParseInt(ttlString, 10, 64); err != nil {
+		api.respondGeneric(w, r, err)
+	}
+	if ttlMinutes != 0 {
+		expireAt = time.Now().Add(time.Duration(ttlMinutes) * time.Minute)
+	}
+
+	err = api.consensusService.SkipHost(hostName, expireAt)
+
+	api.respondGeneric(w, r, err)
+}
+
+func (api *APIImpl) RecoverHost(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	hostName := ps.ByName("hostName")
+	err := api.consensusService.RecoverHost(hostName)
+
+	api.respondGeneric(w, r, err)
+}
+
+func (api *APIImpl) SkippedHosts(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(api.consensusService.SkippedHostsMap())
+}
+
 // ConfigureRoutes configures a set of HTTP routes to be actions dispatched by the
 // given api's methods.
 func ConfigureRoutes(api API) *httprouter.Router {
@@ -367,6 +403,11 @@ func ConfigureRoutes(api API) *httprouter.Router {
 	register(router, "/throttled-apps", api.ThrottledApps)
 	register(router, "/recent-apps", api.RecentApps)
 	register(router, "/recent-apps/:lastMinutes", api.RecentApps)
+
+	register(router, "/skip-host/:hostName", api.SkipHost)
+	register(router, "/skipped-hosts/:hostName/ttl/:ttlMinutes", api.SkipHost)
+	register(router, "/skipped-hosts", api.SkippedHosts)
+	register(router, "/recover-host/:hostName", api.RecoverHost)
 
 	register(router, "/debug/vars", metricsHandle)
 	register(router, "/debug/metrics", metricsHandle)

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -41,6 +41,7 @@ const nonDeprioritizedAppMapExpiration = time.Second
 const nonDeprioritizedAppMapInterval = 100 * time.Millisecond
 
 const DefaultThrottleTTLMinutes = 60
+const DefaultSkipTTLMinutes = 60
 const DefaultThrottleRatio = 1.0
 
 func init() {
@@ -62,6 +63,7 @@ type Throttler struct {
 	mysqlClusterThresholds  *cache.Cache
 	aggregatedMetrics       *cache.Cache
 	throttledApps           *cache.Cache
+	skippedHosts            *cache.Cache
 	recentApps              *cache.Cache
 	metricsHealth           *cache.Cache
 	shareDomainMetricHealth *cache.Cache
@@ -72,6 +74,7 @@ type Throttler struct {
 	proxysqlClient *proxysql.Client
 
 	throttledAppsMutex sync.Mutex
+	skippedHostsMutex  sync.Mutex
 
 	nonLowPriorityAppRequestsThrottled *cache.Cache
 	httpClient                         *http.Client
@@ -89,6 +92,7 @@ func NewThrottler() *Throttler {
 		mysqlInventory:         mysql.NewMySQLInventory(),
 
 		throttledApps:           cache.New(cache.NoExpiration, 10*time.Second),
+		skippedHosts:            cache.New(cache.NoExpiration, 10*time.Second),
 		mysqlClusterThresholds:  cache.New(cache.NoExpiration, 0),
 		aggregatedMetrics:       cache.New(aggregatedMetricsExpiration, aggregatedMetricsCleanup),
 		recentApps:              cache.New(recentAppsExpiration, time.Minute),
@@ -548,6 +552,43 @@ func (throttler *Throttler) ThrottledAppsMap() (result map[string](*base.AppThro
 	for appName, item := range throttler.throttledApps.Items() {
 		appThrottle := item.Object.(*base.AppThrottle)
 		result[appName] = appThrottle
+	}
+	return result
+}
+
+func (throttler *Throttler) SkipHost(hostName string, expireAt time.Time) {
+	throttler.skippedHostsMutex.Lock()
+	defer throttler.skippedHostsMutex.Unlock()
+
+	now := time.Now()
+	var t time.Time
+	if object, found := throttler.skippedHosts.Get(hostName); found {
+		t = object.(time.Time)
+		if !t.IsZero() {
+			expireAt = t
+		}
+	}
+
+	if expireAt.IsZero() {
+		expireAt = now.Add(DefaultSkipTTLMinutes * time.Minute)
+	}
+
+	if now.Before(expireAt) {
+		throttler.skippedHosts.Set(hostName, expireAt, cache.DefaultExpiration)
+	} else {
+		throttler.RecoverHost(hostName)
+	}
+}
+
+func (throttler *Throttler) RecoverHost(hostName string) {
+	throttler.skippedHosts.Delete(hostName)
+}
+
+func (throttler *Throttler) SkippedHostsMap() map[string]time.Time {
+	result := make(map[string]time.Time)
+	for hostName, item := range throttler.skippedHosts.Items() {
+		expireAt := item.Object.(time.Time)
+		result[hostName] = expireAt
 	}
 	return result
 }

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -284,6 +284,10 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 				return
 			}
 		}
+		if _, skipped := throttler.skippedHosts.Get(key.Hostname); skipped {
+			log.Debugf("host skipped: %+v", key.Hostname)
+			return
+		}
 		if !key.IsValid() {
 			log.Debugf("read invalid instance key: [%+v] for cluster %+v", key, clusterName)
 			return
@@ -338,9 +342,6 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 					InstanceProbes:       mysql.NewProbes(),
 				}
 				for _, host := range totalHosts {
-					if _, skipped := throttler.skippedHosts.Get(host); skipped {
-						continue
-					}
 					key := mysql.InstanceKey{Hostname: host, Port: clusterSettings.Port}
 					addInstanceKey(&key, clusterName, clusterSettings, clusterProbes.InstanceProbes)
 				}

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -580,14 +580,6 @@ func (throttler *Throttler) SkipHost(hostName string, expireAt time.Time) {
 	defer throttler.skippedHostsMutex.Unlock()
 
 	now := time.Now()
-	var t time.Time
-	if object, found := throttler.skippedHosts.Get(hostName); found {
-		t = object.(time.Time)
-		if !t.IsZero() {
-			expireAt = t
-		}
-	}
-
 	if expireAt.IsZero() {
 		expireAt = now.Add(DefaultSkipTTLMinutes * time.Minute)
 	}


### PR DESCRIPTION
adds GET endpoints from https://github.com/github/freno/issues/28 for skipping hosts dyanmically
`/skip-host/:hostName`
`/skip-host/:hostName/ttl/:ttlMinutes`
`/skipped-hosts`
`/recover-host/:hostName`

Implemented for raft and mysql backends. For MySQL backend it requires new table
```
CREATE TABLE skipped_hosts (
   host_name varchar(128) NOT NULL,
   skipped_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   expires_at TIMESTAMP NOT NULL,
   PRIMARY KEY (host_name)
);
```

closes #28 
