### PR TITLE
Throttle app by cluster

### DIFF
--- a/doc/http.md
+++ b/doc/http.md
@@ -49,7 +49,7 @@ Notes:
   - `/throttle-app/archive/ttl/30/ratio/1`: completely refuse `/check/archive/*` requests for a duration of `30` minutes
   - `/throttle-app/archive/ttl/30/ratio/0.9`: _mostly_ refuse `/check/archive/*` requests for a duration of `30` minutes. On average (random dice roll), `9` out of `10` requests (i.e. `90%`) will be denied, and one approved.
   - `/throttle-app/archive/ttl/30/ratio/0.5`: refuse `50%` of `/check/archive/*` requests for a duration of `30` minutes
-
+  
 - `/throttle-app/<app-name>/ttl/<ttlMinutes>`:
 
   - If app is already throttled, modify TTL portion only, without changing the ratio.
@@ -65,7 +65,8 @@ Notes:
 
   Same as calling `/throttle-app/<app-name>/ttl/60/ratio/1`. Provided as convenience endpoint.
 
-- `/unthrottle-app/<app-name>`: remove any imposed throttling constraint from given app. Example:
+- `/throttle-app` can take a query parameter `store_name` to throttle the app only on one store (i.e. MySQL cluster). For example `/throttle-app/archive?store_name=mycluster` refuses `/check/archive/mysql/mycluster` requests for `1` hour.
+
 
   `/unthrottle-app/archive` will re-allow the `archive` app to get valid response from `/check/archive/*` requests.
 

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -235,11 +235,21 @@ func (api *APIImpl) MetricsHealth(w http.ResponseWriter, r *http.Request, ps htt
 
 // ThrottleApp forcibly marks given app as throttled. Future requests by this app may be denied.
 func (api *APIImpl) ThrottleApp(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	appName := ps.ByName("app")
+	storeName := r.URL.Query().Get("store_name")
+	var appName string
+	if storeName != "" {
+		// limit throttling to this store
+		appName = fmt.Sprintf("%s/%s", ps.ByName("app"), storeName)
+	} else {
+		// default is throttle app globally
+		appName = ps.ByName("app")
+	}
+
 	var expireAt time.Time // default zero
 	var ttlMinutes int64
 	var ratio float64
 	var err error
+
 	if ps.ByName("ttlMinutes") == "" {
 		ttlMinutes = 0
 	} else if ttlMinutes, err = strconv.ParseInt(ps.ByName("ttlMinutes"), 10, 64); err != nil {

--- a/pkg/throttle/check.go
+++ b/pkg/throttle/check.go
@@ -48,7 +48,7 @@ func (check *ThrottlerCheck) checkAppMetricResult(appName string, storeType stri
 		}
 	}
 	//
-	metricResult, threshold := check.throttler.AppRequestMetricResult(appName, metricResultFunc, denyApp)
+	metricResult, threshold := check.throttler.AppRequestMetricResult(appName, storeName, metricResultFunc, denyApp)
 	if flags.OverrideThreshold > 0 {
 		threshold = flags.OverrideThreshold
 	}

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -527,7 +527,7 @@ func (throttler *Throttler) UnthrottleApp(appName string) {
 	appWithStore := appName + "/"
 	for app, _ := range throttler.throttledApps.Items() {
 		if app == appName || strings.HasPrefix(app, appWithStore) {
-			throttler.throttledApps.Delete(appName)
+			throttler.throttledApps.Delete(app)
 		}
 	}
 }


### PR DESCRIPTION
When manually throttling an app, usually we want to throttle for only one cluster, not globally.
This adds `store_name` query parameter for `/throttle-app` endpoint to throttle app on specific store. On the backend it just uses `app/store` as key so no change to backend storage needed.

`/throttle-app/<app>`: throttle app globally
`/thottle-app/<app>?store_name=<cluster>`: throttle app on cluster
`/unthrottle-app/<app>`: unthrottle app globally and on all clusters

cc/ https://github.com/github/database-infrastructure/issues/4420