### PR TITLE
Fix goreleaser empty_folders

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,8 +33,8 @@ nfpms:
         dst: "/etc/init.d/freno"
         file_info:
           mode: 0777
-    empty_folders:
-      - "/var/lib/freno"
+      - dst: "/var/lib/freno"
+        type: dir
     formats:
       - deb
       - rpm


### PR DESCRIPTION
empty_folders is deprecated so goreleaser fails, see https://goreleaser.com/deprecations/#nfpmsempty_folders