### PR TITLE
Add collation settings to allow collation to override charset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.17
+        go-version: 1.19
       id: go
 
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/internal/raft/net_transport.go
+++ b/internal/raft/net_transport.go
@@ -37,7 +37,6 @@ var (
 )
 
 /*
-
 NetworkTransport provides a network based transport that can be
 used to communicate with Raft on remote machines. It requires
 an underlying stream layer to provide a stream abstraction, which can
@@ -53,7 +52,6 @@ both are encoded using MsgPack.
 InstallSnapshot is special, in that after the RPC request we stream
 the entire state. That socket is not re-used as the connection state
 is not known if there is an error.
-
 */
 type NetworkTransport struct {
 	connPool     map[string][]*netConn

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,8 +106,7 @@ type ConfigurationSettings struct {
 	BackendMySQLSchema   string
 	BackendMySQLUser     string
 	BackendMySQLPassword string
-	BackendCollation     string
-	StoresCollation      string
+	BackendCollation     string   // if specified, use this collation instead of charset when connecting to MySQL backend
 	MemcacheServers      []string // if given, freno will report to aggregated values to given memcache
 	MemcachePath         string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
 	EnableProfiling      bool     // enable pprof profiling http api

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,6 +106,8 @@ type ConfigurationSettings struct {
 	BackendMySQLSchema   string
 	BackendMySQLUser     string
 	BackendMySQLPassword string
+	BackendCollation     string
+	StoresCollation      string
 	MemcacheServers      []string // if given, freno will report to aggregated values to given memcache
 	MemcachePath         string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
 	EnableProfiling      bool     // enable pprof profiling http api

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,25 +92,25 @@ func (config *Configuration) Reload() error {
 // Some of the settinges have reasonable default values, and some other
 // (like database credentials) are strictly expected from user.
 type ConfigurationSettings struct {
-	ListenPort           int
-	DataCenter           string
-	Environment          string
-	Domain               string
-	ShareDomain          string
-	RaftBind             string
-	RaftDataDir          string
-	DefaultRaftPort      int      // if a RaftNodes entry does not specify port, use this one
-	RaftNodes            []string // Raft nodes to make initial connection with
-	BackendMySQLHost     string
-	BackendMySQLPort     int
-	BackendMySQLSchema   string
-	BackendMySQLUser     string
-	BackendMySQLPassword string
-	BackendCollation     string   // if specified, use this collation instead of charset when connecting to MySQL backend
-	MemcacheServers      []string // if given, freno will report to aggregated values to given memcache
-	MemcachePath         string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
-	EnableProfiling      bool     // enable pprof profiling http api
-	Stores               StoresSettings
+	ListenPort            int
+	DataCenter            string
+	Environment           string
+	Domain                string
+	ShareDomain           string
+	RaftBind              string
+	RaftDataDir           string
+	DefaultRaftPort       int      // if a RaftNodes entry does not specify port, use this one
+	RaftNodes             []string // Raft nodes to make initial connection with
+	BackendMySQLHost      string
+	BackendMySQLPort      int
+	BackendMySQLSchema    string
+	BackendMySQLUser      string
+	BackendMySQLPassword  string
+	BackendMySQLCollation string   // if specified, use this collation instead of charset when connecting to MySQL backend
+	MemcacheServers       []string // if given, freno will report to aggregated values to given memcache
+	MemcachePath          string   // use as prefix to metric path in memcache key, e.g. if `MemcachePath` is "myprefix" the key would be "myprefix/mysql/maincluster". Default: "freno"
+	EnableProfiling       bool     // enable pprof profiling http api
+	Stores                StoresSettings
 }
 
 func newConfigurationSettings() *ConfigurationSettings {

--- a/pkg/config/mysql_config.go
+++ b/pkg/config/mysql_config.go
@@ -63,6 +63,7 @@ type MySQLConfigurationSettings struct {
 	ProxySQLUser         string   // ProxySQL stats username
 	ProxySQLPassword     string   // ProxySQL stats password
 	VitessCells          []string // Name of the Vitess cells for polling tablet hosts
+	Collation            string   // MySQL collation to use for stores, replaces charset if specified
 
 	Clusters map[string](*MySQLClusterConfigurationSettings) // cluster name -> cluster config
 }

--- a/pkg/group/mysql.go
+++ b/pkg/group/mysql.go
@@ -77,7 +77,7 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 	if config.Settings().BackendMySQLHost == "" {
 		return nil, nil
 	}
-	dbUri := GetBackendDBUri()
+	dbUri := getBackendDBUri()
 	db, _, err := sqlutils.GetDB(dbUri)
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 }
 
 // helper function to get the DB URI
-func GetBackendDBUri() string {
+func getBackendDBUri() string {
 	dsnCharsetCollation := "charset=utf8mb4,utf8,latin1"
 	if config.Settings().BackendMySQLCollation != "" {
 		// Set collation instead of charset, if BackendMySQLCollation is specified

--- a/pkg/group/mysql.go
+++ b/pkg/group/mysql.go
@@ -78,9 +78,9 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 		return nil, nil
 	}
 	dsnCharsetCollation := "charset=utf8mb4,utf8,latin1"
-	if config.Settings().BackendCollation != "" {
-		// Set collation instead of charset, if BackendCollation is specified
-		dsnCharsetCollation = fmt.Sprintf("collation=%s", config.Settings().BackendCollation)
+	if config.Settings().BackendMySQLCollation != "" {
+		// Set collation instead of charset, if BackendMySQLCollation is specified
+		dsnCharsetCollation = fmt.Sprintf("collation=%s", config.Settings().BackendMySQLCollation)
 	}
 	dbUri := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&%s&timeout=500ms",
 		config.Settings().BackendMySQLUser,

--- a/pkg/group/mysql.go
+++ b/pkg/group/mysql.go
@@ -77,19 +77,7 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 	if config.Settings().BackendMySQLHost == "" {
 		return nil, nil
 	}
-	dsnCharsetCollation := "charset=utf8mb4,utf8,latin1"
-	if config.Settings().BackendMySQLCollation != "" {
-		// Set collation instead of charset, if BackendMySQLCollation is specified
-		dsnCharsetCollation = fmt.Sprintf("collation=%s", config.Settings().BackendMySQLCollation)
-	}
-	dbUri := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&%s&timeout=500ms",
-		config.Settings().BackendMySQLUser,
-		config.Settings().BackendMySQLPassword,
-		config.Settings().BackendMySQLHost,
-		config.Settings().BackendMySQLPort,
-		config.Settings().BackendMySQLSchema,
-		dsnCharsetCollation,
-	)
+	dbUri := GetBackendDBUri()
 	db, _, err := sqlutils.GetDB(dbUri)
 	if err != nil {
 		return nil, err
@@ -116,6 +104,23 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 	}
 	go backend.continuousOperations()
 	return backend, nil
+}
+
+// helper function to get the DB URI
+func GetBackendDBUri() string {
+	dsnCharsetCollation := "charset=utf8mb4,utf8,latin1"
+	if config.Settings().BackendMySQLCollation != "" {
+		// Set collation instead of charset, if BackendMySQLCollation is specified
+		dsnCharsetCollation = fmt.Sprintf("collation=%s", config.Settings().BackendMySQLCollation)
+	}
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&%s&timeout=500ms",
+		config.Settings().BackendMySQLUser,
+		config.Settings().BackendMySQLPassword,
+		config.Settings().BackendMySQLHost,
+		config.Settings().BackendMySQLPort,
+		config.Settings().BackendMySQLSchema,
+		dsnCharsetCollation,
+	)
 }
 
 // Monitor is a utility function to routinely observe leadership state.

--- a/pkg/group/mysql.go
+++ b/pkg/group/mysql.go
@@ -77,8 +77,18 @@ func NewMySQLBackend(throttler *throttle.Throttler) (*MySQLBackend, error) {
 	if config.Settings().BackendMySQLHost == "" {
 		return nil, nil
 	}
-	dbUri := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&charset=utf8mb4,utf8,latin1&timeout=500ms",
-		config.Settings().BackendMySQLUser, config.Settings().BackendMySQLPassword, config.Settings().BackendMySQLHost, config.Settings().BackendMySQLPort, config.Settings().BackendMySQLSchema,
+	dsnCharsetCollation := "charset=utf8mb4,utf8,latin1"
+	if config.Settings().BackendCollation != "" {
+		// Set collation instead of charset, if BackendCollation is specified
+		dsnCharsetCollation = fmt.Sprintf("collation=%s", config.Settings().BackendCollation)
+	}
+	dbUri := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&%s&timeout=500ms",
+		config.Settings().BackendMySQLUser,
+		config.Settings().BackendMySQLPassword,
+		config.Settings().BackendMySQLHost,
+		config.Settings().BackendMySQLPort,
+		config.Settings().BackendMySQLSchema,
+		dsnCharsetCollation,
 	)
 	db, _, err := sqlutils.GetDB(dbUri)
 	if err != nil {

--- a/pkg/group/mysql_test.go
+++ b/pkg/group/mysql_test.go
@@ -25,11 +25,11 @@ func TestGetBackendDBUri(t *testing.T) {
 	config.Settings().BackendMySQLSchema = "test_database"
 
 	// test default (charset)
-	dbUri := GetBackendDBUri()
+	dbUri := getBackendDBUri()
 	test.S(t).ExpectEquals(dbUri, "gromit:penguin@tcp(myhost:3306)/test_database?interpolateParams=true&charset=utf8mb4,utf8,latin1&timeout=500ms")
 
 	// test setting collation
 	config.Settings().BackendMySQLCollation = "utf8mb4_unicode_ci"
-	dbUri = GetBackendDBUri()
+	dbUri = getBackendDBUri()
 	test.S(t).ExpectEquals(dbUri, "gromit:penguin@tcp(myhost:3306)/test_database?interpolateParams=true&collation=utf8mb4_unicode_ci&timeout=500ms")
 }

--- a/pkg/group/mysql_test.go
+++ b/pkg/group/mysql_test.go
@@ -1,0 +1,35 @@
+/*
+   Copyright 2023 GitHub Inc.
+	 See https://github.com/github/freno/blob/master/LICENSE
+*/
+
+package group
+
+import (
+	"testing"
+
+	"github.com/github/freno/pkg/config"
+	"github.com/outbrain/golib/log"
+	test "github.com/outbrain/golib/tests"
+)
+
+func init() {
+	log.SetLevel(log.ERROR)
+}
+
+func TestGetBackendDBUri(t *testing.T) {
+	config.Settings().BackendMySQLUser = "gromit"
+	config.Settings().BackendMySQLPassword = "penguin"
+	config.Settings().BackendMySQLHost = "myhost"
+	config.Settings().BackendMySQLPort = 3306
+	config.Settings().BackendMySQLSchema = "test_database"
+
+	// test default (charset)
+	dbUri := GetBackendDBUri()
+	test.S(t).ExpectEquals(dbUri, "gromit:penguin@tcp(myhost:3306)/test_database?interpolateParams=true&charset=utf8mb4,utf8,latin1&timeout=500ms")
+
+	// test setting collation
+	config.Settings().BackendMySQLCollation = "utf8mb4_unicode_ci"
+	dbUri = GetBackendDBUri()
+	test.S(t).ExpectEquals(dbUri, "gromit:penguin@tcp(myhost:3306)/test_database?interpolateParams=true&collation=utf8mb4_unicode_ci&timeout=500ms")
+}

--- a/pkg/mysql/probe.go
+++ b/pkg/mysql/probe.go
@@ -79,9 +79,9 @@ func (probe *Probe) GetDBUri(databaseName string) string {
 		hostname = fmt.Sprintf("[%s]", hostname)
 	}
 	dsnCharsetCollation := "charset=utf8mb4,utf8,latin1"
-	if config.Settings().StoresCollation != "" {
+	if config.Settings().Stores.MySQL.Collation != "" {
 		// Set collation instead of charset, if StoresCollation is specified
-		dsnCharsetCollation = fmt.Sprintf("collation=%s", config.Settings().StoresCollation)
+		dsnCharsetCollation = fmt.Sprintf("collation=%s", config.Settings().Stores.MySQL.Collation)
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&%s&timeout=%dms",
 		probe.User,

--- a/pkg/mysql/probe.go
+++ b/pkg/mysql/probe.go
@@ -80,7 +80,7 @@ func (probe *Probe) GetDBUri(databaseName string) string {
 	}
 	dsnCharsetCollation := "charset=utf8mb4,utf8,latin1"
 	if config.Settings().Stores.MySQL.Collation != "" {
-		// Set collation instead of charset, if StoresCollation is specified
+		// Set collation instead of charset, if Stores.MySQL.Collation is specified
 		dsnCharsetCollation = fmt.Sprintf("collation=%s", config.Settings().Stores.MySQL.Collation)
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?interpolateParams=true&%s&timeout=%dms",

--- a/pkg/mysql/probe_test.go
+++ b/pkg/mysql/probe_test.go
@@ -8,6 +8,7 @@ package mysql
 import (
 	"testing"
 
+	"github.com/github/freno/pkg/config"
 	"github.com/outbrain/golib/log"
 	test "github.com/outbrain/golib/tests"
 )
@@ -48,4 +49,20 @@ func TestDuplicate(t *testing.T) {
 	test.S(t).ExpectEquals(dup.Key.Port, 3306)
 	test.S(t).ExpectEquals(dup.User, "gromit")
 	test.S(t).ExpectEquals(dup.Password, "penguin")
+}
+
+func TestGetDBUri(t *testing.T) {
+	c := NewProbe()
+	c.Key = InstanceKey{Hostname: "myhost", Port: 3306}
+	c.User = "gromit"
+	c.Password = "penguin"
+
+	// test default (charset)
+	dbUri := c.GetDBUri("test_database")
+	test.S(t).ExpectEquals(dbUri, "gromit:penguin@tcp(myhost:3306)/test_database?interpolateParams=true&charset=utf8mb4,utf8,latin1&timeout=1000ms")
+
+	// test setting collation
+	config.Settings().Stores.MySQL.Collation = "utf8mb4_unicode_ci"
+	dbUri = c.GetDBUri("test_database")
+	test.S(t).ExpectEquals(dbUri, "gromit:penguin@tcp(myhost:3306)/test_database?interpolateParams=true&collation=utf8mb4_unicode_ci&timeout=1000ms")
 }

--- a/pkg/proxysql/client_test.go
+++ b/pkg/proxysql/client_test.go
@@ -51,8 +51,8 @@ func TestProxySQLGetDB(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for failed connection")
 		}
-		if !strings.HasSuffix(err.Error(), "no such host") {
-			t.Fatalf("expected a 'no such host' error, got %v", err)
+		if !strings.HasSuffix(err.Error(), "no such host") && !strings.HasSuffix(err.Error(), "i/o timeout") {
+			t.Fatalf("expected a 'no such host' or 'i/o timeout' error, got %v", err)
 		}
 	})
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,7 +2,7 @@
 
 set -e
 
-readonly supportedGo="go1.1[67]"
+readonly supportedGo="go1.1[6789]"
 
 # Ensure go is installed
 if ! command -v go ; then


### PR DESCRIPTION
This PR introduces two new settings:
- `ConfigurationSettings` -> `BackendCollation` - if specified, sets `collation=?` in the DSN for the backend MySQL database connection, replacing the default `charset=utf8mb4,utf8,latin1` setting
- `MySQLConfigurationSettings `->`Collation` - if specified, sets `collation=?` in the DSN for the monitored MySQL stores connections, replacing the default `charset=utf8mb4,utf8,latin1` setting

When these values are set to a charset that is common between MySQL 5.7 and 8.0 (e.g. `utf8mb4_unicode_520_ci`), this prevents Freno from breaking temporary replication from an 8.0 primary to a 5.7 replica.

This PR does not change the existing behaviour of Freno (i.e. setting `charset=utf8mb4,utf8,latin1`); instead it allows the existing behaviour to be overriden when the new collation settings are specified.

I have not added the new collation parameters to the documentation as they are for a niche use case.

Also in this PR:
- I have also adjusted one of the tests as Actions now results in invalid hosts returning a timeout instead of "no such host" (but the important part of the test is that it fails to connect to an invalid host)
- Added Go 1.18 and 1.19 to supported versions