### PR TITLE
Set IgnoreHostsThreshold in ClusterProbe

### DIFF
--- a/pkg/mysql/mysql_http_check.go
+++ b/pkg/mysql/mysql_http_check.go
@@ -40,7 +40,6 @@ func MySQLHttpCheckHashKey(clusterName string, key *InstanceKey) string {
 }
 
 func CheckHttp(clusterName string, probe *Probe) (httpCheckResult *MySQLHttpCheck) {
-
 	if probe.HttpCheckPort <= 0 {
 		go func() { metrics.GetOrRegisterCounter("httpcheck.skip", nil).Inc(1) }()
 		return NewMySQLHttpCheck(clusterName, &probe.Key, http.StatusOK)

--- a/pkg/throttle/mysql.go
+++ b/pkg/throttle/mysql.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/github/freno/pkg/base"
 	"github.com/github/freno/pkg/mysql"
-	"github.com/outbrain/golib/log"
 )
 
 func aggregateMySQLProbes(
@@ -32,7 +31,6 @@ func aggregateMySQLProbes(
 
 		value, err := instanceMetricResult.Get()
 		if err != nil {
-			log.Errorf("error getting metric from %s: %v", probe.Key.Hostname, err)
 			if ignoreDialTcpErrors && base.IsDialTcpError(err) {
 				continue
 			}

--- a/pkg/throttle/mysql.go
+++ b/pkg/throttle/mysql.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/github/freno/pkg/base"
 	"github.com/github/freno/pkg/mysql"
+	"github.com/outbrain/golib/log"
 )
 
 func aggregateMySQLProbes(
@@ -31,6 +32,7 @@ func aggregateMySQLProbes(
 
 		value, err := instanceMetricResult.Get()
 		if err != nil {
+			log.Errorf("error getting metric from %s: %v", probe.Key.Hostname, err)
 			if ignoreDialTcpErrors && base.IsDialTcpError(err) {
 				continue
 			}

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -365,9 +365,10 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 				}
 				log.Debugf("Read %+v hosts from ProxySQL %s, hostgroup id: %d (%s)", len(servers), dsn, clusterSettings.ProxySQLSettings.HostgroupID, clusterName)
 				clusterProbes := &mysql.ClusterProbes{
-					ClusterName:      clusterName,
-					IgnoreHostsCount: clusterSettings.IgnoreHostsCount,
-					InstanceProbes:   mysql.NewProbes(),
+					ClusterName:          clusterName,
+					IgnoreHostsCount:     clusterSettings.IgnoreHostsCount,
+					IgnoreHostsThreshold: clusterSettings.IgnoreHostsThreshold,
+					InstanceProbes:       mysql.NewProbes(),
 				}
 				for _, server := range servers {
 					key := mysql.InstanceKey{Hostname: server.Host, Port: int(server.Port)}
@@ -389,9 +390,10 @@ func (throttler *Throttler) refreshMySQLInventory() error {
 					keyspace, shard, strings.Join(vitess.ParseCells(clusterSettings.VitessSettings), ","),
 				)
 				clusterProbes := &mysql.ClusterProbes{
-					ClusterName:      clusterName,
-					IgnoreHostsCount: clusterSettings.IgnoreHostsCount,
-					InstanceProbes:   mysql.NewProbes(),
+					ClusterName:          clusterName,
+					IgnoreHostsCount:     clusterSettings.IgnoreHostsCount,
+					IgnoreHostsThreshold: clusterSettings.IgnoreHostsThreshold,
+					InstanceProbes:       mysql.NewProbes(),
 				}
 				for _, tablet := range tablets {
 					key := mysql.InstanceKey{Hostname: tablet.MysqlHostname, Port: int(tablet.MysqlPort)}


### PR DESCRIPTION
The `IgnoreHostsThreshold` in the cluster probe was not getting set to the value from the config when the cluster is using Vitess or ProxySQL.
This causes `IgnoreHostsCount` hosts to be ignored regardless of what the configured `IgnoreHostsThreshold` value is.