### PR TITLE
Add Permanent Throttle Option

### DIFF
--- a/doc/mysql-backend.md
+++ b/doc/mysql-backend.md
@@ -78,7 +78,7 @@ CREATE TABLE service_election (
 CREATE TABLE throttled_apps (
   app_name varchar(128) NOT NULL,
 	throttled_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  expires_at TIMESTAMP NOT NULL,
+  expires_at TIMESTAMP,
 	ratio DOUBLE,
   PRIMARY KEY (app_name)
 );

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -41,7 +41,6 @@ const skippedHostsSnapshotInterval = 5 * time.Second
 const nonDeprioritizedAppMapExpiration = time.Second
 const nonDeprioritizedAppMapInterval = 100 * time.Millisecond
 
-const DefaultThrottleTTLMinutes = 60
 const DefaultSkipTTLMinutes = 60
 const DefaultThrottleRatio = 1.0
 
@@ -524,15 +523,12 @@ func (throttler *Throttler) ThrottleApp(appName string, expireAt time.Time, rati
 			appThrottle.Ratio = ratio
 		}
 	} else {
-		if expireAt.IsZero() {
-			expireAt = now.Add(DefaultThrottleTTLMinutes * time.Minute)
-		}
 		if ratio < 0 {
 			ratio = DefaultThrottleRatio
 		}
 		appThrottle = base.NewAppThrottle(expireAt, ratio)
 	}
-	if now.Before(appThrottle.ExpireAt) {
+	if now.Before(appThrottle.ExpireAt) || expireAt.IsZero() {
 		throttler.throttledApps.Set(appName, appThrottle, cache.DefaultExpiration)
 	} else {
 		throttler.UnthrottleApp(appName)

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -518,6 +518,8 @@ func (throttler *Throttler) ThrottleApp(appName string, expireAt time.Time, rati
 		appThrottle = object.(*base.AppThrottle)
 		if !expireAt.IsZero() {
 			appThrottle.ExpireAt = expireAt
+		} else {
+			appThrottle.ExpireAt = time.Time{}
 		}
 		if ratio >= 0 {
 			appThrottle.Ratio = ratio

--- a/pkg/throttle/throttler.go
+++ b/pkg/throttle/throttler.go
@@ -528,8 +528,12 @@ func (throttler *Throttler) ThrottleApp(appName string, expireAt time.Time, rati
 		}
 		appThrottle = base.NewAppThrottle(expireAt, ratio)
 	}
-	if now.Before(appThrottle.ExpireAt) || expireAt.IsZero() {
-		throttler.throttledApps.Set(appName, appThrottle, cache.DefaultExpiration)
+	
+	if expireAt.IsZero() {
+		//If expires at is zero, update the store to never expire the throttle
+		throttler.throttledApps.Set(appName, appThrottle, -1)
+	} else if now.Before(appThrottle.ExpireAt) {
+			throttler.throttledApps.Set(appName, appThrottle, cache.DefaultExpiration)
 	} else {
 		throttler.UnthrottleApp(appName)
 	}

--- a/vendor/github.com/patrickmn/go-cache/cache.go
+++ b/vendor/github.com/patrickmn/go-cache/cache.go
@@ -54,7 +54,6 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
 	} else if d == NoExpiration {
-		d = c.NoExpiration
 		e = -1
 	}
 	if d > 0 {
@@ -75,7 +74,6 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
 	} else if d == NoExpiration {
-		d = c.NoExpiration
 		e = -1
 	}
 	if d > 0 {

--- a/vendor/github.com/patrickmn/go-cache/cache.go
+++ b/vendor/github.com/patrickmn/go-cache/cache.go
@@ -56,6 +56,8 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 	}
 	if d > 0 {
 		e = time.Now().Add(d).UnixNano()
+	} else if d == -1 {
+		e = time.Time{}
 	}
 	c.mu.Lock()
 	c.items[k] = Item{
@@ -74,6 +76,8 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 	}
 	if d > 0 {
 		e = time.Now().Add(d).UnixNano()
+	} else if d == -1  { 
+		e = time.Time{}
 	}
 	c.items[k] = Item{
 		Object:     x,

--- a/vendor/github.com/patrickmn/go-cache/cache.go
+++ b/vendor/github.com/patrickmn/go-cache/cache.go
@@ -54,10 +54,12 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
 	} else if d == NoExpiration {
+		d = c.NoExpiration
 		e = -1
 	}
 	if d > 0 {
 		e = time.Now().Add(d).UnixNano()
+	}
 	c.mu.Lock()
 	c.items[k] = Item{
 		Object:     x,
@@ -73,6 +75,7 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
 	} else if d == NoExpiration {
+		d = c.NoExpiration
 		e = -1
 	}
 	if d > 0 {

--- a/vendor/github.com/patrickmn/go-cache/cache.go
+++ b/vendor/github.com/patrickmn/go-cache/cache.go
@@ -53,12 +53,11 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 	var e int64
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
+	} else if d == NoExpiration {
+		e = -1
 	}
 	if d > 0 {
 		e = time.Now().Add(d).UnixNano()
-	} else if d == -1 {
-		e = time.Time{}
-	}
 	c.mu.Lock()
 	c.items[k] = Item{
 		Object:     x,
@@ -73,12 +72,12 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 	var e int64
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
+	} else if d == NoExpiration {
+		e = -1
 	}
 	if d > 0 {
 		e = time.Now().Add(d).UnixNano()
-	} else if d == -1  { 
-		e = time.Time{}
-	}
+	} 
 	c.items[k] = Item{
 		Object:     x,
 		Expiration: e,


### PR DESCRIPTION
Updates to change the default TTL behavior to never expire, per [this issue](https://github.com/github/database-infrastructure/issues/5627).