### PR TITLE
Emit internal error metrics

### DIFF
--- a/pkg/throttle/check.go
+++ b/pkg/throttle/check.go
@@ -124,6 +124,14 @@ func (check *ThrottlerCheck) Check(appName string, storeType string, storeName s
 
 			metrics.GetOrRegisterCounter(fmt.Sprintf("check.any.%s.%s.error", storeType, storeName), nil).Inc(1)
 			metrics.GetOrRegisterCounter(fmt.Sprintf("check.%s.%s.%s.error", appName, storeType, storeName), nil).Inc(1)
+
+			if statusCode == http.StatusInternalServerError {
+				metrics.GetOrRegisterCounter("check.any.internal-error", nil).Inc(1)
+				metrics.GetOrRegisterCounter(fmt.Sprintf("check.%s.internal-error", appName), nil).Inc(1)
+
+				metrics.GetOrRegisterCounter(fmt.Sprintf("check.any.%s.%s.internal-error", storeType, storeName), nil).Inc(1)
+				metrics.GetOrRegisterCounter(fmt.Sprintf("check.%s.%s.%s.internal-error", appName, storeType, storeName), nil).Inc(1)
+			}
 		}
 
 		check.throttler.markRecentApp(appName, remoteAddr)


### PR DESCRIPTION
This should be changed to use `statsd` at some point, since our `go-expvar` metrics don't support tagging, which is why we need to emit metrics in this format.

Difference between `check.any.error` and the newly introduced `check.any.internal-error` is that `check.any.error` counts anything that is a status code 200 as an error. This includes all rate limiting events. 


Tracking `check.any.internal-error` will make it possible for us to track actual errors that are caused by `freno` not being able to connect to mysql, or freno failing in any other way. 