### PR TITLE
Add permissions to GitHub actions workflows, update actions versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,13 +2,16 @@ name: CI
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
 
     - name: Set up Go
       uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,25 +5,29 @@ on:
     tags:
       - '*'
 
+# Minimal permissions required for GoReleaser to create GitHub Releases
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.19
+          go-version-file: 'go.mod'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request attempts to fix two of the code scanning issues found:
Missing permissions block in the GitHub actions workflows.

It also updates the versions of the used GitHub actions and uses the `go.mod` file to determine the Go version for the release workflow.

The `--rm-dist` flag for goreleaser has been deprecated in favor of `--clean` and was removed in v2. ([docs](https://goreleaser.com/deprecations/#-rm-dist))
