### PR TITLE
fix: correct typo 'commited' to 'committed' in raft comments

### DIFF
--- a/internal/raft/inflight_test.go
+++ b/internal/raft/inflight_test.go
@@ -17,12 +17,12 @@ func TestInflight_StartCommit(t *testing.T) {
 	// Commit 3 times
 	in.Commit(1)
 	if in.Committed().Len() != 0 {
-		t.Fatalf("should not be commited")
+		t.Fatalf("should not be committed")
 	}
 
 	in.Commit(1)
 	if in.Committed().Len() != 1 {
-		t.Fatalf("should be commited")
+		t.Fatalf("should be committed")
 	}
 
 	// Already committed but should work anyways

--- a/internal/raft/raft.go
+++ b/internal/raft/raft.go
@@ -51,7 +51,7 @@ var (
 	ErrUnknownPeer = errors.New("peer is unknown")
 
 	// ErrNothingNewToSnapshot is returned when trying to create a snapshot
-	// but there's nothing new commited to the FSM since we started.
+	// but there's nothing new committed to the FSM since we started.
 	ErrNothingNewToSnapshot = errors.New("Nothing new to snapshot")
 )
 

--- a/internal/raft/raft_test.go
+++ b/internal/raft/raft_test.go
@@ -1390,7 +1390,7 @@ func TestRaft_ManualSnapshot(t *testing.T) {
 	defer c.Close()
 
 	leader := c.Leader()
-	// with nothing commited, asking for a snapshot should return an error
+	// with nothing committed, asking for a snapshot should return an error
 	ssErr := leader.Snapshot().Error()
 	if ssErr != ErrNothingNewToSnapshot {
 		t.Errorf("Attempt to manualy create snapshot should of errored because there's nothing to do: %v", ssErr)


### PR DESCRIPTION
Fixes #175